### PR TITLE
Add start and end date query parameters to isolates list method

### DIFF
--- a/amr_tv/isolate/views.py
+++ b/amr_tv/isolate/views.py
@@ -14,7 +14,8 @@ class IsolateViewSet(ReadOnlyModelViewSet):
     def list(self, request):
         """Lists all isolates over optionally supplied time period.
 
-        Overrides superclass method.
+        Overrides superclass method. If end_date is supplied,
+        end_date-1 is used.
 
         :param request: May contain query parameters start_date and
         end_date.

--- a/amr_tv/isolate/views.py
+++ b/amr_tv/isolate/views.py
@@ -1,3 +1,4 @@
+from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from amr_tv.isolate.models import Isolate
@@ -9,3 +10,24 @@ class IsolateViewSet(ReadOnlyModelViewSet):
     queryset = Isolate.objects.all().order_by("-create_date")
     serializer_class = IsolateSerializer
     lookup_value_regex = '[\w.]+'
+
+    def list(self, request):
+        """Lists all isolates over optionally supplied time period.
+
+        Overrides superclass method.
+
+        :param request: May contain query parameters start_date and
+        end_date.
+        """
+        start_date = request.query_params.get("start_date", "0001-01-01")
+        end_date = request.query_params.get("end_date", "9999-01-01")
+        queryset = self.get_queryset()
+        queryset = queryset.filter(create_date__range=(start_date, end_date))
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
Can now get isolates over user-specified time period.

Both query parameters are optional.