### PR TITLE
Add secondary y-axis

### DIFF
--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -1,17 +1,17 @@
 {
   "delimiter": "\t",
   "node_id": "sample id",
-  "track": "sequence type",
+  "primary_y": "incompatibility group",
+  "secondary_y": "sequence type",
   "date_attr": "sample date",
   "date_format": "%B %Y",
   "label_attr": "sample id",
   "attr_link_list": [
-    "Tn4401 variant",
-    "Tn4401 isoform"
+    "Tn4401 variant"
   ],
   "node_color_attr": "",
   "node_symbol_attr": "species",
-  "links_across_y": 1,
+  "links_across_y": 0,
   "max_day_range": 6000,
   "null_vals": [""],
   "y_key": "str"

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -1,7 +1,8 @@
 {
   "delimiter": ",",
   "node_id": "Sample ID / Isolate",
-  "track": "Location",
+  "primary_y": "Location",
+  "secondary_y": "rep_type(s)",
   "date_attr": "Date of collection",
   "date_format": "%B %Y",
   "label_attr": "Patient ID",
@@ -10,12 +11,11 @@
     "Resitance gene type",
     "SNPs_homozygous",
     "Left_flanks;Right_flanks",
-    "mash_neighbor_cluster",
-    "rep_type(s)"
+    "mash_neighbor_cluster"
   ],
   "node_color_attr": "mash_neighbor_cluster",
   "node_symbol_attr": "Organism",
-  "links_across_y": 1,
+  "links_across_y": 0,
   "max_day_range": 60,
   "null_vals": ["", "-"],
   "y_key": "str"

--- a/sample_files/mulvey_data.tsv
+++ b/sample_files/mulvey_data.tsv
@@ -2,9 +2,9 @@ sample id	sample date	sequence type	species	incompatibility group	Tn4401 variant
 A	October 2011	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a
 B	September 2012	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a
 C	June 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-D	July 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-E	November 2014	ST354	K. oxytoca	IncP, L/M	Tn4401b-1	b
-F	November 2014	ST354	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-G	November 2014	ST1846	Escherichia coli	IncN	Tn4401b-2	b
+D	July 2014	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b
+E	November 2014	n/a	K. oxytoca	IncP, L/M	Tn4401b-1	b
+F	November 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b
+G	November 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b
 H	December 2014	ST1846	Escherichia coli	IncN	Tn4401b-2	b
-I	January 2015	n/a	Klebsiella pneumoniae	IncN	Tn4401b-2	b
+I	January 2015	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b


### PR DESCRIPTION
Users do not specify ``track`` in config file anymore. Instead specify ``primary_y`` and ``secondary_y``. The latter can be an empty str if no secondary y-axis is desired. Facet lines separate by ``primary_y``. Currently y-axis tick labels are in the following format: ``{primary_y_val},{secondary_y_val}``.