### PR TITLE
Implement weighted links

### DIFF
--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -15,5 +15,6 @@
   "node_symbol_attr": "role",
   "links_across_y": 1,
   "max_day_range": 6000,
-  "null_vals": ["n/a"]
+  "null_vals": ["n/a"],
+  "weights": {}
 }

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -16,5 +16,8 @@
   "node_symbol_attr": "species",
   "links_across_y": 0,
   "max_day_range": 6000,
-  "null_vals": [""]
+  "null_vals": [""],
+  "weights": {
+    "sequence type": "@SNV distance@-!SNV distance!"
+  }
 }

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -9,7 +9,9 @@
   "date_attr": "sample date",
   "date_format": "%B %Y",
   "label_attr": "sample id",
-  "attr_link_list": [],
+  "attr_link_list": [
+    "sequence type"
+  ],
   "node_color_attr": "",
   "node_symbol_attr": "species",
   "links_across_y": 0,

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -19,5 +19,6 @@
   "node_symbol_attr": "Organism",
   "links_across_y": 0,
   "max_day_range": 60,
-  "null_vals": ["", "-"]
+  "null_vals": ["", "-"],
+  "weights": {}
 }

--- a/config_files/senterica_clusters_12012021_config.json
+++ b/config_files/senterica_clusters_12012021_config.json
@@ -15,5 +15,5 @@
   "links_across_y": "True",
   "max_day_range": 14,
   "null_vals": ["", "-"],
-  "selected_nodes": {}
+  "weights": {}
 }

--- a/data_parser.py
+++ b/data_parser.py
@@ -133,6 +133,15 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         yaxis_range=yaxis_range
     )
 
+    main_fig_attr_link_labels_dict = get_main_fig_attr_link_labels_dict(
+        sample_links_dict=sample_links_dict,
+        main_fig_nodes_x_dict=main_fig_nodes_x_dict,
+        main_fig_nodes_y_dict=main_fig_nodes_y_dict,
+        selected_samples=selected_samples,
+        yaxis_range=yaxis_range,
+        weights=config_file_dict["weights"]
+    )
+
     main_fig_attr_link_tips_dict = \
         get_main_fig_attr_link_tips_dict(main_fig_attr_links_dict)
 
@@ -184,6 +193,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
             main_fig_nodes_textfont_color,
         "node_color_attr_dict": node_color_attr_dict,
         "main_fig_attr_links_dict": main_fig_attr_links_dict,
+        "main_fig_attr_link_labels_dict": main_fig_attr_link_labels_dict,
         "attr_color_dash_dict": attr_color_dash_dict,
         "main_fig_attr_link_tips_dict": main_fig_attr_link_tips_dict,
         "main_fig_facet_x":
@@ -352,10 +362,11 @@ def get_node_color_attr_dict(node_color_attr_list):
 def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
                           links_across_y, max_day_range, null_vals, weights):
     """Get a dict of all links to viz in main graph.
-    TODO
 
-    The keys in the dict are different attrs. The values are a list of
-    tuples containing two samples with a shared val for that attr.
+    The keys in the dict are different attrs. The values are a nested
+    dict. The keys in the nested dict are tuples containing two samples
+    with a shared val for the attr key in the outer dict. The values in
+    the nested dict are weights assigned to that link.
 
     :param sample_data_dict: ``get_sample_data_dict`` ret val
     :type sample_data_dict: dict
@@ -370,6 +381,9 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
     :type max_day_range: int
     :param null_vals: List of null vals in sample data
     :type null_vals: list
+    :param weights: Dictionary of expressions used to assign weights to
+        specific attr links
+    :type weights: dict
     :return: Dict detailing links to viz in main graph
     :rtype: dict
     """
@@ -535,6 +549,102 @@ def get_main_fig_attr_links_dict(sample_links_dict, main_fig_nodes_x_dict,
             else:
                 ret[attr]["opaque"]["x"] += [x0, x1, None]
                 ret[attr]["opaque"]["y"] += [y0, y1, None]
+
+    return ret
+
+
+def get_main_fig_attr_link_labels_dict(sample_links_dict,
+                                       main_fig_nodes_x_dict,
+                                       main_fig_nodes_y_dict, selected_samples,
+                                       yaxis_range, weights):
+    """Get dict with info used by Plotly to viz link labels.
+
+    TODO: there may be a better way to do this. Certainly, the code
+          used to calculate the midpoints does not need to be repeated
+          each loop. We'll keep it there in case we decide to translate
+          different labels parallel-wise later.
+
+    Current logic:
+    * Put labels parallel to midpoint of centermost line between nodes
+    * Multiple labels occupy the same vertical plane--offsetted along
+      x-axis only
+
+    :param sample_links_dict: ``get_sample_links_dict`` ret val
+    :type sample_links_dict: dict
+    :param main_fig_nodes_x_dict: ``get_main_fig_nodes_x_dict`` ret val
+    :type main_fig_nodes_x_dict: dict
+    :param main_fig_nodes_y_dict: ``get_main_fig_nodes_y_dict`` ret val
+    :type main_fig_nodes_y_dict: dict
+    :param selected_samples: Samples selected by users
+    :type selected_samples: set[str]
+    :param yaxis_range: Main graph y-axis min and max val
+    :type yaxis_range: list
+    :param weights: Dictionary of expressions used to assign weights to
+        specific attr links
+    :type weights: dict
+    :return: Dict with info used by Plotly to viz links in main graph
+    :rtype: dict
+    """
+    ret = {}
+    label_count_dict = {}
+    min_multiplier = len(sample_links_dict)/2 + 1
+    unit_parallel_translation = (yaxis_range[1] - yaxis_range[0]) / 100
+    parallel_translation = min_multiplier * unit_parallel_translation
+    for attr in sample_links_dict:
+        if attr not in weights:
+            continue
+
+        ret[attr] = {
+            "opaque": {"x": [], "y": [], "text": []},
+            "transparent": {"x": [], "y": [], "text": []}
+        }
+
+        for (sample, other_sample) in sample_links_dict[attr]:
+            if (sample, other_sample) in label_count_dict:
+                label_count_dict[(sample, other_sample)] += 1
+                label_count = label_count_dict[(sample, other_sample)]
+            else:
+                label_count = 1
+                label_count_dict[(sample, other_sample)] = label_count
+
+            x0 = main_fig_nodes_x_dict[sample]
+            y0 = main_fig_nodes_y_dict[sample]
+            x1 = main_fig_nodes_x_dict[other_sample]
+            y1 = main_fig_nodes_y_dict[other_sample]
+
+            if (x1 - x0) == 0:
+                x0 += parallel_translation
+                x1 += parallel_translation
+            elif (y1 - y0) == 0:
+                y0 += parallel_translation
+                y1 += parallel_translation
+            else:
+                inverse_perpendicular_slope = (x1 - x0) / (y1 - y0)
+                numerator = parallel_translation**2
+                denominator = 1 + inverse_perpendicular_slope**2
+                x_translation = sqrt(numerator/denominator)
+                if parallel_translation < 0:
+                    x_translation *= -1
+                x0 += x_translation
+                x1 += x_translation
+                y0 += -inverse_perpendicular_slope * x_translation
+                y1 += -inverse_perpendicular_slope * x_translation
+
+            xmid = (x0 + x1) / 2 + \
+                   (label_count - 1) * 3 * unit_parallel_translation
+            ymid = (y0 + y1) / 2
+            weight = sample_links_dict[attr][(sample, other_sample)]
+
+            selected_link = \
+                sample in selected_samples or other_sample in selected_samples
+            if selected_samples and not selected_link:
+                ret[attr]["transparent"]["x"].append(xmid)
+                ret[attr]["transparent"]["y"].append(ymid)
+                ret[attr]["transparent"]["text"].append(weight)
+            else:
+                ret[attr]["opaque"]["x"].append(xmid)
+                ret[attr]["opaque"]["y"].append(ymid)
+                ret[attr]["opaque"]["text"].append(weight)
 
     return ret
 

--- a/expression_evaluator.py
+++ b/expression_evaluator.py
@@ -31,4 +31,6 @@ def eval_(node):
     elif isinstance(node, ast.UnaryOp):
         return OPERATORS[type(node.op)](eval_(node.operand))
     else:
-        raise TypeError(node)
+        raise TypeError("Encountered value that was not a number or operator "
+                        "when parsing weight expression. Did you reference a "
+                        "categorical attribute?")

--- a/expression_evaluator.py
+++ b/expression_evaluator.py
@@ -18,12 +18,24 @@ OPERATORS = {
 
 
 def eval_expr(expr):
-    """TODO"""
+    """Evaluate str expression consisting of constants and arithmetic.
+
+    :param expr: AST node containing simple arithmetic and constants
+    :type expr: str
+    :return: Evaluated value of expr
+    :rtype: str
+    """
     return eval_(ast.parse(expr, mode='eval').body)
 
 
 def eval_(node):
-    """TODO"""
+    """Parse leaf AST nodes sent from ``eval_expr``.
+
+    :param node: AST
+    :type node: ast.expr
+    :return: Evaluation of leaf node
+    :rtype: str
+    """
     if isinstance(node, ast.Num):
         return node.n
     elif isinstance(node, ast.BinOp):

--- a/expression_evaluator.py
+++ b/expression_evaluator.py
@@ -1,0 +1,34 @@
+"""Module for evaluating str expressions.
+
+Significantly influenced by 
+https://stackoverflow.com/a/9558001/11472358.
+"""
+
+import ast
+import operator as op
+
+# Supported operators
+OPERATORS = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.USub: op.neg
+}
+
+
+def eval_expr(expr):
+    """TODO"""
+    return eval_(ast.parse(expr, mode='eval').body)
+
+
+def eval_(node):
+    """TODO"""
+    if isinstance(node, ast.Num):
+        return node.n
+    elif isinstance(node, ast.BinOp):
+        return OPERATORS[type(node.op)](eval_(node.left), eval_(node.right))
+    elif isinstance(node, ast.UnaryOp):
+        return OPERATORS[type(node.op)](eval_(node.operand))
+    else:
+        raise TypeError(node)

--- a/legend_fig_generator.py
+++ b/legend_fig_generator.py
@@ -79,6 +79,10 @@ def get_link_legend_fig_links(app_data):
     for i, attr in enumerate(app_data["main_fig_attr_links_dict"]):
         (r, g, b) = app_data["attr_color_dash_dict"][attr][0]
         dash = app_data["attr_color_dash_dict"][attr][1]
+        if attr in app_data["main_fig_attr_link_labels_dict"]:
+            label = attr + " (weighted)"
+        else:
+            label = attr
         links.append(
             go.Scatter(
                 x=[0, 1],
@@ -89,7 +93,7 @@ def get_link_legend_fig_links(app_data):
                     "color": "rgb(%s, %s, %s)" % (r, g, b),
                     "dash": dash
                 },
-                text=["<b>%s</b>" % attr, None],
+                text=["<b>%s</b>" % label, None],
                 textfont={
                     "color": "black",
                     "size": 16

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -83,6 +83,54 @@ def get_main_fig_attr_link_graphs(app_data):
     return ret
 
 
+def get_main_fig_attr_link_label_graphs(app_data):
+    """Get plotly scatter objs of links labels in main fig.
+
+    This is basically a list of different scatter objs--one for each
+    attr label type.
+
+    :param app_data: ``data_parser.get_app_data`` ret val
+    :type app_data: dict
+    :return: Plotly scatter objs of link labels in main fig
+    :rtype: list[go.Scatter]
+    """
+    ret = []
+    for attr in app_data["main_fig_attr_link_labels_dict"]:
+        opaque_dict = \
+            app_data["main_fig_attr_link_labels_dict"][attr]["opaque"]
+        opaque_x = opaque_dict["x"]
+        opaque_y = opaque_dict["y"]
+        opaque_text = opaque_dict["text"]
+        transparent_dict = \
+            app_data["main_fig_attr_link_labels_dict"][attr]["transparent"]
+        transparent_x = transparent_dict["x"]
+        transparent_y = transparent_dict["y"]
+        transparent_text = transparent_dict["text"]
+        (r, g, b) = app_data["attr_color_dash_dict"][attr][0]
+
+        opaque_graph = go.Scatter(
+            x=opaque_x,
+            y=opaque_y,
+            text=opaque_text,
+            mode="text",
+            textfont={
+                "color": "rgb(%s,%s,%s)" % (r, g, b),
+                "size": 16
+            }
+        )
+
+        transparent_graph = go.Scatter(
+            x=transparent_x,
+            y=transparent_y,
+            text=transparent_text,
+            mode="text"
+        )
+
+        ret += [opaque_graph, transparent_graph]
+
+    return ret
+
+
 def get_main_fig_attr_link_tip_graphs(app_data):
     """Get plotly scatter objs of lin tips in main fig.
 
@@ -158,9 +206,10 @@ def get_main_fig(app_data):
     # TODO decide what to do with these
     # main_fig_attr_link_tip_graphs = \
     #     get_main_fig_attr_link_tip_graphs(app_data)
-    main_fig_attr_link_tip_graphs = []
+    main_fig_attr_link_label_graphs = \
+        get_main_fig_attr_link_label_graphs(app_data)
     fig = go.Figure(
-        data=main_fig_attr_link_graphs + main_fig_attr_link_tip_graphs + [
+        data=main_fig_attr_link_graphs + main_fig_attr_link_label_graphs + [
             get_main_fig_nodes(app_data),
             get_main_fig_facet_lines(app_data)
         ],

--- a/sample_files/mulvey_data.tsv
+++ b/sample_files/mulvey_data.tsv
@@ -1,10 +1,10 @@
-sample id	sample date	sequence type	species	incompatibility group	Tn4401 variant	Tn4401 isoform
-A	October 2011	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a
-B	September 2012	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a
-C	June 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-D	July 2014	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-E	November 2014	n/a	K. oxytoca	IncP, L/M	Tn4401b-1	b
-F	November 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b
-G	November 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b
-H	December 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b
-I	January 2015	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b
+sample id	sample date	sequence type	species	incompatibility group	Tn4401 variant	Tn4401 isoform	SNV distance
+A	October 2011	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a	0
+B	September 2012	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a	4
+C	June 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b	0
+D	July 2014	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b	0
+E	November 2014	n/a	K. oxytoca	IncP, L/M	Tn4401b-1	b	0
+F	November 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b	3
+G	November 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b	0
+H	December 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b	38
+I	January 2015	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b	6


### PR DESCRIPTION
Links can now be assigned weights. A ``weights`` parameter in the config file accepts str expressions that calculate weights for links. The expressions can reference attrs in the samples of the link with the following formats: `!attr1!` and `@attr2@1, where the former refers to `attr1` value from the earlier sample, and the latter to the `attr2` value of the later sample in the link.

The weights are drawn on the graph as link labels. The labels are in the middle of link.

Things get a little messy when there are >2 labels, and frankly we need to implement intelligent routing at some point or it can be confusing which label a link refers to.

We added SNV distance between samples sharing the same sequence type in the mulvey data now.