### PR TITLE
Allow users to filter links by weight and attr values

### DIFF
--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -21,5 +21,6 @@
     "not_equal": {},
     "less_than": {},
     "greater_than": {}
-  }
+  },
+  "attr_val_filters": {}
 }

--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -16,5 +16,10 @@
   "links_across_y": 1,
   "max_day_range": 6000,
   "null_vals": ["n/a"],
-  "weights": {}
+  "weights": {},
+  "weight_filters": {
+    "not_equal": {},
+    "less_than": {},
+    "greater_than": {}
+  }
 }

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -19,5 +19,10 @@
   "null_vals": [""],
   "weights": {
     "sequence type": "@SNV distance@-!SNV distance!"
+  },
+  "weight_filters": {
+    "not_equal": {},
+    "less_than": {},
+    "greater_than": {}
   }
 }

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -24,5 +24,6 @@
     "not_equal": {},
     "less_than": {},
     "greater_than": {}
-  }
+  },
+  "attr_val_filters": {}
 }

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -25,5 +25,6 @@
     "not_equal": {},
     "less_than": {},
     "greater_than": {}
-  }
+  },
+  "attr_val_filters": {}
 }

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -20,5 +20,10 @@
   "links_across_y": 0,
   "max_day_range": 60,
   "null_vals": ["", "-"],
-  "weights": {}
+  "weights": {},
+  "weight_filters": {
+    "not_equal": {},
+    "less_than": {},
+    "greater_than": {}
+  }
 }

--- a/config_files/senterica_clusters_12012021_config.json
+++ b/config_files/senterica_clusters_12012021_config.json
@@ -20,5 +20,6 @@
     "not_equal": {},
     "less_than": {},
     "greater_than": {}
-  }
+  },
+  "attr_val_filters": {}
 }

--- a/config_files/senterica_clusters_12012021_config.json
+++ b/config_files/senterica_clusters_12012021_config.json
@@ -15,5 +15,10 @@
   "links_across_y": "True",
   "max_day_range": 14,
   "null_vals": ["", "-"],
-  "weights": {}
+  "weights": {},
+  "weight_filters": {
+    "not_equal": {},
+    "less_than": {},
+    "greater_than": {}
+  }
 }

--- a/data_parser.py
+++ b/data_parser.py
@@ -121,7 +121,8 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         links_across_y=config_file_dict["links_across_y"],
         max_day_range=config_file_dict["max_day_range"],
         null_vals=config_file_dict["null_vals"],
-        weights=config_file_dict["weights"]
+        weights=config_file_dict["weights"],
+        weight_filters=config_file_dict["weight_filters"]
     )
 
     attr_color_dash_dict = get_attr_color_dash_dict(sample_links_dict)
@@ -361,8 +362,10 @@ def get_node_color_attr_dict(node_color_attr_list):
 
 
 def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
-                          links_across_y, max_day_range, null_vals, weights):
+                          links_across_y, max_day_range, null_vals, weights,
+                          weight_filters):
     """Get a dict of all links to viz in main graph.
+    TODO
 
     The keys in the dict are different attrs. The values are a nested
     dict. The keys in the nested dict are tuples containing two samples
@@ -440,6 +443,19 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
                         weight_exp = weights[attr]
                         subbed_exp = regex_obj.sub(repl_fn, weight_exp)
                         link_weight = eval_expr(subbed_exp)
+
+                        if attr in weight_filters["not_equal"]:
+                            neq = weight_filters["not_equal"][attr]
+                            if link_weight == neq:
+                                continue
+                        if attr in weight_filters["less_than"]:
+                            le = weight_filters["less_than"][attr]
+                            if link_weight < le:
+                                continue
+                        if attr in weight_filters["greater_than"]:
+                            ge = weight_filters["greater_than"][attr]
+                            if link_weight > ge:
+                                continue
                     else:
                         link_weight = 0
 

--- a/data_parser.py
+++ b/data_parser.py
@@ -11,6 +11,7 @@ from re import compile
 
 from expression_evaluator import eval_expr
 
+
 def get_app_data(sample_file_base64_str, config_file_base64_str,
                  selected_nodes=None, xaxis_range=None, yaxis_range=None):
     """Get data from uploaded file that is used to generate viz.

--- a/data_parser.py
+++ b/data_parser.py
@@ -122,7 +122,8 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         max_day_range=config_file_dict["max_day_range"],
         null_vals=config_file_dict["null_vals"],
         weights=config_file_dict["weights"],
-        weight_filters=config_file_dict["weight_filters"]
+        weight_filters=config_file_dict["weight_filters"],
+        attr_val_filters=config_file_dict["attr_val_filters"]
     )
 
     attr_color_dash_dict = get_attr_color_dash_dict(sample_links_dict)
@@ -363,14 +364,16 @@ def get_node_color_attr_dict(node_color_attr_list):
 
 def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
                           links_across_y, max_day_range, null_vals, weights,
-                          weight_filters):
+                          weight_filters, attr_val_filters):
     """Get a dict of all links to viz in main graph.
-    TODO
 
     The keys in the dict are different attrs. The values are a nested
     dict. The keys in the nested dict are tuples containing two samples
     with a shared val for the attr key in the outer dict. The values in
     the nested dict are weights assigned to that link.
+
+    We filter out certain links using ``weight_filters`` and
+    ``attr_val_filters``.
 
     :param sample_data_dict: ``get_sample_data_dict`` ret val
     :type sample_data_dict: dict
@@ -388,6 +391,9 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
     :param weights: Dictionary of expressions used to assign weights to
         specific attr links
     :type weights: dict
+    :param attr_val_filters: Dictionary of vals to ignore for certain
+        attrs, when generating links.
+    :type attr_val_filters: dict
     :return: Dict detailing links to viz in main graph
     :rtype: dict
     """
@@ -404,6 +410,15 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
             sample_attr_list = \
                 [sample_data_dict[sample][v] for v in attr_list]
             if any(v in null_vals for v in sample_attr_list):
+                continue
+            # Bit of a complex comprehension. Basically, we remove any
+            # values in sample_attr_list that are belong to a val
+            # specified for the attr in attr_val_filters.
+            sample_attr_list = \
+                [y for x, y in zip(attr_list, sample_attr_list)
+                 if
+                 x not in attr_val_filters or y not in attr_val_filters[x]]
+            if not sample_attr_list:
                 continue
 
             for j in range(i+1, len(sample_list)):
@@ -424,6 +439,11 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
 
                 other_sample_attr_list = \
                     [sample_data_dict[other_sample][v] for v in attr_list]
+                # See sample_attr_list comment
+                other_sample_attr_list = \
+                    [y for x, y in zip(attr_list, other_sample_attr_list)
+                     if
+                     x not in attr_val_filters or y not in attr_val_filters[x]]
 
                 if sample_attr_list == other_sample_attr_list:
                     if attr in weights:


### PR DESCRIPTION
Users can now specify filters used to exclude certain links. Here is an example of the required parameters:
```
"weight_filters": {
  "not_equal": {
    "some_attr1": 12
  },
  "less_than": {
    "some_attr2": 6
  },
  "greater_than": {
    "some_attr3": 9
  },
},
"attr_val_filters": {
  "another_attr": ["foo", "bar"]
}
```
In this example, any links for ``some_attr1`` with the weight `12` would not be drawn. Any links for ``some_attr2`` and ``some_attr3`` with weights less than 6 and greater than 9 respectively would not be drawn either. When drawing links using the ``another_attr``, the values ``foo`` and ``bar`` for that attribute will be ignored in making comparisons b/w samples.