### PR TITLE
Allow users to specify date output format in viz

### DIFF
--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -6,7 +6,8 @@
     "location"
   ],
   "date_attr": "date",
-  "date_format": "%b %d %Y",
+  "date_input": "%b %d %Y",
+  "date_output": "%d-%m-%Y",
   "label_attr": "patient_id",
   "attr_link_list": [
     "family"

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -7,7 +7,8 @@
     "Tn4401 variant"
   ],
   "date_attr": "sample date",
-  "date_format": "%B %Y",
+  "date_input": "%B %Y",
+  "date_output": "%B %Y",
   "label_attr": "sample id",
   "attr_link_list": [
     "sequence type"

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -6,7 +6,8 @@
     "rep_type(s)"
   ],
   "date_attr": "Date of collection",
-  "date_format": "%B %Y",
+  "date_input": "%B %Y",
+  "date_output": "%B %Y",
   "label_attr": "Patient ID",
   "attr_link_list": [
     "F1: MLST type",

--- a/config_files/senterica_clusters_12012021_config.json
+++ b/config_files/senterica_clusters_12012021_config.json
@@ -6,7 +6,8 @@
     "site_order"
   ],
   "date_attr": "collection_date",
-  "date_format": "%Y-%m-%d %H:%M:%S",
+  "date_input": "%Y-%m-%d %H:%M:%S",
+  "date_output": "%Y-%m-%d",
   "label_attr": "Sample",
   "attr_link_list": [
   ],


### PR DESCRIPTION
Instead of ``date_format``, users now specify ``date_input`` and ``date_output`` in the config file.

``date_input`` is the format of the user submitted data.

``date_output`` is the format the user wishes to plot along the x-axis.

Importantly, this allows users to bin their data by choosing outputs that are less granular than their input. e.g., ``date_input`` is ``%d-%m-%Y``, while ``date_output`` is ``%m-%Y``.