### PR TITLE
Better null val handling

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -173,6 +173,10 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
     else:
         main_fig_nodes_textfont_color = "black"
 
+    main_fig_yaxis_ticktext = \
+        ["<br>".join(["null" if e is None else e for e in k])
+         for k in track_y_vals_dict]
+
     app_data = {
         "node_shape_legend_fig_nodes_y":
             list(range(len(node_symbol_attr_dict))),
@@ -191,7 +195,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         "main_fig_yaxis_tickvals":
             list(track_y_vals_dict.values()),
         "main_fig_yaxis_ticktext":
-            ["<br>".join(k) for k in track_y_vals_dict],
+            main_fig_yaxis_ticktext,
         "main_fig_nodes_x":
             [main_fig_nodes_x_dict[k] for k in sample_data_dict],
         "main_fig_nodes_y":
@@ -259,7 +263,7 @@ def sorting_key(track):
 
     We sort as follows:
 
-    * "n/a" comes first
+    * None comes first
     * Sort ints next
     * Sort strs last
 
@@ -272,13 +276,13 @@ def sorting_key(track):
     for attr_val in track:
         try:
             ret.append((
-                attr_val == "n/a",
+                attr_val is None,
                 0,
                 int(attr_val)
              ))
-        except ValueError:
+        except (TypeError, ValueError):
             ret.append((
-                attr_val == "n/a",
+                attr_val is None,
                 1,
                 attr_val
              ))
@@ -319,7 +323,7 @@ def get_sample_data_dict(sample_file_str, delimiter, node_id, date,
             continue
         if row[date] in null_vals:
             continue
-        row = {k: ("n/a" if row[k] in null_vals else row[k]) for k in row}
+        row = {k: (None if row[k] in null_vals else row[k]) for k in row}
 
         row["datetime_obj"] = datetime.strptime(row[date], date_input)
         row[date] = row["datetime_obj"].strftime(date_output)

--- a/data_parser.py
+++ b/data_parser.py
@@ -464,8 +464,6 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
                  x not in attr_val_filters or y not in attr_val_filters[x]
                  else None
                  for x, y in zip(attr_list, sample_attr_list)]
-            if not sample_attr_list:
-                continue
 
             for j in range(i+1, len(sample_list)):
                 other_sample = sample_list[j]

--- a/sample_files/mulvey_data.tsv
+++ b/sample_files/mulvey_data.tsv
@@ -3,7 +3,7 @@ A	October 2011	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a	0
 B	September 2012	ST512	Klebsiella pneumoniae	IncFII(k)	Tn4401a-1	a	4
 C	June 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b	0
 D	July 2014	ST1846	Klebsiella pneumoniae	IncN	Tn4401b-2	b	0
-E	November 2014	n/a	K. oxytoca	IncP, L/M	Tn4401b-1	b	0
+E	November 2014		K. oxytoca	IncP, L/M	Tn4401b-1	b	0
 F	November 2014	ST252	Klebsiella pneumoniae	IncN	Tn4401b-2	b	3
 G	November 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b	0
 H	December 2014	ST354	Escherichia coli	IncN	Tn4401b-2	b	38


### PR DESCRIPTION
Instead of replacing null vals with ``"n/a"``, we replace them with ``None``. Python successfully converts ``None`` to non-str ``null`` when moving between dicts and json. Only intervention needed was when labeling the y-axis, where None has to be manually converted to the str ``"null"``.

In addition, we were throwing out links where any val in the attribute list encoded by the link was ``None``. e.g., ``[None, "apple"]`` would not match with ``[None, "apple"]``, but ``["apple"]`` would match with ``["apple"]``. We stopped doing this.

I also replaced a ``"n/a"`` val in the mulvey dataset with an empty str.