### PR TITLE
Allow overlapping match links

### DIFF
--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -16,7 +16,7 @@
   ],
   "node_color_attr": "",
   "node_symbol_attr": "species",
-  "links_across_primary_y": 0,
+  "links_across_primary_y": 1,
   "max_day_range": 6000,
   "null_vals": [""],
   "weights": {

--- a/data_parser.py
+++ b/data_parser.py
@@ -440,9 +440,15 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
     regex_obj = compile("!.*?!|@.*?@")
 
     for attr in attr_link_list:
+        looking_for_any_overlap = False
+        if attr[0] == "(" and attr[-1] == ")":
+            looking_for_any_overlap = True
+
         attr_list = []
         disjoint_match_list = []
-        for attr_list_val in attr.split(";"):
+        attr_split = \
+            (attr[1:-1] if looking_for_any_overlap else attr).split(";")
+        for attr_list_val in attr_split:
             if attr_list_val[0] == "~":
                 disjoint_match_list.append(True)
                 attr_list.append(attr_list_val[1:])
@@ -506,7 +512,9 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
                     else:
                         matches.append(True)
 
-                if all(matches):
+                is_a_link = \
+                    any(matches) if looking_for_any_overlap else all(matches)
+                if is_a_link:
                     if attr in weights:
                         def repl_fn(match_obj):
                             match = match_obj.group(0)


### PR DESCRIPTION
Users can now surround their link specifications in parentheses to generate links between any nodes that have a union of matches across the attributes in the link.

For example, if the link is specified as ``"fruit;vegetable"``, and the value for these attributes across two nodes are ``"banana;carrot"`` and ``"apple;carrot"``, then a link will not be formed between the two nodes because the values for ``fruit`` do not match (even though the values for ``vegetable`` do!).

But a link **will be** formed if it was instead specified as ``"(fruit;vegetable)"``, because this tells the application to look for a union of values, and the values for ``vegetable`` match--so a union exists.