### PR TITLE
Update colour/dash scheme for attr links

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -135,7 +135,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         attr_val_filters=config_file_dict["attr_val_filters"]
     )
 
-    attr_color_dash_dict = get_attr_color_dash_dict(sample_links_dict)
+    attr_link_color_dict = get_attr_link_color_dict(sample_links_dict)
 
     main_fig_attr_links_dict = get_main_fig_attr_links_dict(
         sample_links_dict=sample_links_dict,
@@ -212,7 +212,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         "node_color_attr_dict": node_color_attr_dict,
         "main_fig_attr_links_dict": main_fig_attr_links_dict,
         "main_fig_attr_link_labels_dict": main_fig_attr_link_labels_dict,
-        "attr_color_dash_dict": attr_color_dash_dict,
+        "attr_link_color_dict": attr_link_color_dict,
         "main_fig_attr_link_tips_dict": main_fig_attr_link_tips_dict,
         "main_fig_primary_facet_x":
             get_main_fig_primary_facet_x(default_xaxis_range,
@@ -558,24 +558,28 @@ def get_sample_links_dict(sample_data_dict, attr_link_list, primary_y,
     return sample_links_dict
 
 
-def get_attr_color_dash_dict(sample_links_dict):
-    """Get dict assigning color/dash combo to attrs vized as links.
+def get_attr_link_color_dict(sample_links_dict):
+    """Get dict assigning color to attrs vized as links.
+
+    # TODO: color blind safe? Color/pattern combos get confusing
 
     :param sample_links_dict: ``get_sample_links_dict`` ret val
     :type sample_links_dict: dict
-    :return: Dict with attrs vized as links as keys,
-        and a unique color/dash combo as vals.
+    :return: Dict with attrs vized as links as keys, and a unique color
+        as vals.
     :rtype: dict
     """
-    available_link_color_dash_combos = [
-        ((27, 158, 119), "solid"), ((217, 95, 2), "solid"),
-        ((117, 112, 179), "solid"), ((27, 158, 119), "dot"),
-        ((217, 95, 2), "dot"), ((117, 112, 179), "dot"),
+    available_attr_link_color_list = [
+        (228, 26, 28),
+        (55, 126, 184),
+        (77, 175, 74),
+        (152, 78, 163),
+        (255, 127, 0)
     ]
-    if len(sample_links_dict) > len(available_link_color_dash_combos):
-        msg = "Not enough unique edge patterns for different attributes"
+    if len(sample_links_dict) > len(available_attr_link_color_list):
+        msg = "Not enough unique colors for different attributes"
         raise IndexError(msg)
-    zip_obj = zip(sample_links_dict.keys(), available_link_color_dash_combos)
+    zip_obj = zip(sample_links_dict.keys(), available_attr_link_color_list)
     ret = {k: v for (k, v) in zip_obj}
     return ret
 

--- a/legend_fig_generator.py
+++ b/legend_fig_generator.py
@@ -77,8 +77,7 @@ def get_link_legend_fig_links(app_data):
     """
     links = []
     for i, attr in enumerate(app_data["main_fig_attr_links_dict"]):
-        (r, g, b) = app_data["attr_color_dash_dict"][attr][0]
-        dash = app_data["attr_color_dash_dict"][attr][1]
+        (r, g, b) = app_data["attr_link_color_dict"][attr]
         if attr in app_data["main_fig_attr_link_labels_dict"]:
             label = attr + " (weighted)"
         else:
@@ -90,8 +89,7 @@ def get_link_legend_fig_links(app_data):
                 mode="lines+text",
                 line={
                     "width": 3,
-                    "color": "rgb(%s, %s, %s)" % (r, g, b),
-                    "dash": dash
+                    "color": "rgb(%s, %s, %s)" % (r, g, b)
                 },
                 text=["<b>%s</b>" % label, None],
                 textfont={

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -55,8 +55,7 @@ def get_main_fig_attr_link_graphs(app_data):
             app_data["main_fig_attr_links_dict"][attr]["transparent"]["x"]
         transparent_y = \
             app_data["main_fig_attr_links_dict"][attr]["transparent"]["y"]
-        (r, g, b) = app_data["attr_color_dash_dict"][attr][0]
-        dash = app_data["attr_color_dash_dict"][attr][1]
+        (r, g, b) = app_data["attr_link_color_dict"][attr]
 
         opaque_graph = go.Scatter(
             x=[x if x else None for x in opaque_x],
@@ -64,8 +63,7 @@ def get_main_fig_attr_link_graphs(app_data):
             mode="lines",
             line={
                 "width": 3,
-                "color": "rgb(%s,%s,%s)" % (r, g, b),
-                "dash": dash
+                "color": "rgb(%s,%s,%s)" % (r, g, b)
             }
         )
         transparent_graph = go.Scatter(
@@ -74,8 +72,7 @@ def get_main_fig_attr_link_graphs(app_data):
             mode="lines",
             line={
                 "width": 3,
-                "color": "rgba(%s,%s,%s, 0.5)" % (r, g, b),
-                "dash": dash
+                "color": "rgba(%s,%s,%s, 0.5)" % (r, g, b)
             }
         )
         ret += [opaque_graph, transparent_graph]
@@ -106,7 +103,7 @@ def get_main_fig_attr_link_label_graphs(app_data):
         transparent_x = transparent_dict["x"]
         transparent_y = transparent_dict["y"]
         transparent_text = transparent_dict["text"]
-        (r, g, b) = app_data["attr_color_dash_dict"][attr][0]
+        (r, g, b) = app_data["attr_link_color_dict"][attr]
 
         opaque_graph = go.Scatter(
             x=opaque_x,


### PR DESCRIPTION
All links are now solid. Having links of the same colour, but different dash patterns, became confusing with link overlap. Perhaps revisit this idea after implementing an edge routing algorithm?

Changed colour scheme, and capped number of available colours to 5. So we can viz 5 different links at a time.