### PR TITLE
Implement zoomed-out version of main fig

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,13 +56,29 @@ def launch_app(_):
         dbc.Row(
             children=[
                 dbc.Col(
-                    children=dcc.Graph(
-                        figure={},
-                        id="main-graph"
-                    ),
-                    style={"height": "90vh",
-                           "width": "80vw",
-                           "overflow": "scroll"}
+                    dbc.Tabs(
+                        children=[
+                            dbc.Tab(
+                                dcc.Graph(
+                                    figure={},
+                                    id="main-graph"
+                                ),
+                                label="Zoomed in",
+                                style={"height": "90vh",
+                                       "width": "80vw",
+                                       "overflow": "scroll"}
+                            ),
+                            dbc.Tab(
+                                dcc.Graph(
+                                    figure={},
+                                    id="zoomed-out-main-graph"
+                                ),
+                                label="Zoomed out",
+                                style={"height": "90vh",
+                                       "width": "80vw"}
+                            )
+                        ]
+                    )
                 ),
                 dbc.Col(
                     children=[

--- a/app.py
+++ b/app.py
@@ -61,7 +61,8 @@ def launch_app(_):
                             dbc.Tab(
                                 dcc.Graph(
                                     figure={},
-                                    id="main-graph"
+                                    id="main-graph",
+                                    config={"displayModeBar": False}
                                 ),
                                 label="Zoomed in",
                                 style={"height": "90vh",
@@ -72,6 +73,7 @@ def launch_app(_):
                                 dcc.Graph(
                                     figure={},
                                     id="zoomed-out-main-graph",
+                                    config={"displayModeBar": False},
                                     style={"height": "85vh",
                                            "width": "75vw"}
                                 ),
@@ -145,6 +147,7 @@ def launch_app(_):
             id="upload-data-modal"
         ),
         dcc.Store(id="selected-nodes", data={}),
+        # TODO remove ranges and dragmode
         dcc.Store(id="xaxis-range"),
         dcc.Store(id="yaxis-range"),
         dcc.Store(id="dragmode", data="zoom"),
@@ -304,6 +307,7 @@ def select_nodes(click_data, selected_nodes):
 )
 def update_ranges(relayout_data, dragmode):
     """Update axes range and drag mode browser vars after relayout.
+    TODO remove this
 
     :param relayout_data: Information on graph after automatic Plotly-
         or user-driven layout updates
@@ -370,6 +374,7 @@ def update_ranges(relayout_data, dragmode):
 def update_main_viz(selected_nodes, xaxis_range, yaxis_range, _,
                     sample_file_contents, config_file_contents, dragmode):
     """Update main graph and legends. TODO
+    TODO remove dragmode
 
     Current triggers:
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ Running this script launches the application.
 import dash
 from dash import Dash
 from dash.dash import no_update
-from dash.dependencies import Input, Output, State
+from dash.dependencies import ClientsideFunction, Input, Output, State
 from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
@@ -64,6 +64,8 @@ def launch_app(_):
                                     id="main-graph",
                                     config={"displayModeBar": False}
                                 ),
+                                id="main-graph-tab",
+                                tab_id="main-graph-tab",
                                 label="Zoomed in",
                                 style={"height": "90vh",
                                        "width": "80vw",
@@ -77,11 +79,13 @@ def launch_app(_):
                                     style={"height": "85vh",
                                            "width": "75vw"}
                                 ),
+                                id="zoomed-out-main-graph-tab",
                                 label="Zoomed out",
                                 style={"height": "90vh",
                                        "width": "80vw"}
                             )
-                        ]
+                        ],
+                        id="main-viz-tabs"
                     )
                 ),
                 dbc.Col(
@@ -441,6 +445,17 @@ def update_main_viz(selected_nodes, xaxis_range, yaxis_range, _,
             link_legend_fig,
             node_color_legend_fig)
 
+
+app.clientside_callback(
+    ClientsideFunction(
+        namespace="clientside",
+        function_name="scrollToNode"
+    ),
+    Output("main-viz-tabs", "active_tab"),
+    Output("zoomed-out-main-graph", "clickData"),
+    Input("zoomed-out-main-graph", "clickData"),
+    prevent_initial_call=True
+)
 
 if __name__ == "__main__":
     app.run_server(debug=True)

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 
 from data_parser import get_app_data
-from main_fig_generator import get_main_fig
+from main_fig_generator import get_main_figs
 from legend_fig_generator import (get_node_symbol_legend_fig,
                                   get_link_legend_fig,
                                   get_node_color_legend_fig)
@@ -71,7 +71,9 @@ def launch_app(_):
                             dbc.Tab(
                                 dcc.Graph(
                                     figure={},
-                                    id="zoomed-out-main-graph"
+                                    id="zoomed-out-main-graph",
+                                    style={"height": "85vh",
+                                           "width": "75vw"}
                                 ),
                                 label="Zoomed out",
                                 style={"height": "90vh",
@@ -358,6 +360,7 @@ def update_ranges(relayout_data, dragmode):
     output=[
         Output("main-graph", "figure"),
         Output("main-graph", "style"),
+        Output("zoomed-out-main-graph", "figure"),
         Output("node-shape-legend-graph", "figure"),
         Output("link-legend-graph", "figure"),
         Output("node-color-legend-graph", "figure"),
@@ -366,7 +369,7 @@ def update_ranges(relayout_data, dragmode):
 )
 def update_main_viz(selected_nodes, xaxis_range, yaxis_range, _,
                     sample_file_contents, config_file_contents, dragmode):
-    """Update main graph and legends.
+    """Update main graph and legends. TODO
 
     Current triggers:
 
@@ -412,22 +415,23 @@ def update_main_viz(selected_nodes, xaxis_range, yaxis_range, _,
                                 xaxis_range=xaxis_range,
                                 yaxis_range=yaxis_range,
                                 selected_nodes=selected_nodes)
-        new_main_fig = get_main_fig(app_data)
+        main_fig, zoomed_out_main_fig = get_main_figs(app_data)
     elif trigger == "viz-btn.n_clicks":
         app_data = get_app_data(sample_file_base64_str, config_file_base64_str)
-        new_main_fig = get_main_fig(app_data)
+        main_fig, zoomed_out_main_fig = get_main_figs(app_data)
     else:
         msg = "Unexpected trigger trying to update main graph: %s" % trigger
         raise RuntimeError(msg)
 
     main_fig_style = {"height": app_data["main_fig_height"],
-                      "width": app_data["main_fig_width"]}
+                                "width": app_data["main_fig_width"]}
     node_symbol_legend_fig = get_node_symbol_legend_fig(app_data)
     link_legend_fig = get_link_legend_fig(app_data)
     node_color_legend_fig = get_node_color_legend_fig(app_data)
 
-    return (new_main_fig,
+    return (main_fig,
             main_fig_style,
+            zoomed_out_main_fig,
             node_symbol_legend_fig,
             link_legend_fig,
             node_color_legend_fig)

--- a/app.py
+++ b/app.py
@@ -316,12 +316,12 @@ def select_nodes(click_data, selected_nodes):
 )
 def update_main_viz(selected_nodes, _, sample_file_contents,
                     config_file_contents):
-    """Update main graph and legends. TODO
+    """Update main graph, zoomed-out main graph, and legends.
 
     Current triggers:
 
     * User clicks viz btn (after uploading data)
-    * User selects node
+    * User selects node in main graph
 
     :param selected_nodes: Currently selected nodes
     :type selected_nodes: dict
@@ -368,6 +368,8 @@ def update_main_viz(selected_nodes, _, sample_file_contents,
             node_color_legend_fig)
 
 
+# Switch to main graph tab and scroll to corresponding node, after
+# clicking node in zoomed-out main graph.
 app.clientside_callback(
     ClientsideFunction(
         namespace="clientside",

--- a/assets/clientside-callbacks.js
+++ b/assets/clientside-callbacks.js
@@ -5,7 +5,13 @@
 window.dash_clientside = Object.assign({}, window.dash_clientside, {
   clientside: {
     /**
-     * TODO
+     * Switch to main graph, and scroll to corresponding node, after
+     * user clicks node in zoomed-out main graph.
+     * @param {Object} clickData Plotly object containing info on last node
+     *     clicked in zoomed-out main graph.
+     * @return {Array.<?string>} The id of the main graph tab, which is made
+     *     active, and a null value, which is used to reset the last node
+     *     clicked.
      */
     scrollToNode: (clickData) => {
       const mainGraph = document.getElementById('main-graph');

--- a/assets/clientside-callbacks.js
+++ b/assets/clientside-callbacks.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview This file stores callbacks that are performed clientside.
+ */
+
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+  clientside: {
+    /**
+     * TODO
+     */
+    scrollToNode: (clickData) => {
+      const mainGraph = document.getElementById('main-graph');
+      const mainGraphPoints = mainGraph.getElementsByClassName('point');
+      const clickedPoint = clickData['points'][0]['pointIndex'];
+
+      // We need to add the active class to the main graph tab, otherwise
+      // ``scrollIntoView`` does not work.
+      document.getElementById('main-graph-tab').classList.add('active');
+
+      const scrollIntoViewOptions = {'block': 'center', 'inline': 'center'}
+      mainGraphPoints[clickedPoint].scrollIntoView(scrollIntoViewOptions);
+
+      // Remove the active class, and let the return value make it active. There
+      // seems to be more to fully activating tabs than just changing classes.
+      document.getElementById('main-graph-tab').classList.remove('active');
+
+      return ['main-graph-tab', null];
+    }
+  }
+});

--- a/data_parser.py
+++ b/data_parser.py
@@ -961,10 +961,16 @@ def get_main_fig_nodes_y_dict(sample_data_dict, date_attr,
 
 def get_main_fig_nodes_hovertext(sample_data_dict, main_fig_nodes_text,
                                  date_list, track_list, attr_link_list):
-    """Get hovertext for nodes in main fig.TODO
+    """Get hovertext for nodes in main fig.
 
     :param sample_data_dict: Sample file data parsed into dict obj
     :type sample_data_dict: dict
+    :param main_fig_nodes_text: List of node labels wrt all nodes
+    :type main_fig_nodes_text: list[str]
+    :param date_list: List of sample dates wrt all nodes
+    :type date_list: list
+    :param track_list: List of sample tracks wrt all nodes
+    :type track_list: list
     :param attr_link_list: list of attrs to include in ret dict
     :type attr_link_list: list[str]
     :return: List of d3-formatted text to display on hover across all

--- a/data_parser.py
+++ b/data_parser.py
@@ -111,8 +111,15 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         node_color_attr_dict = {}
         main_fig_nodes_marker_color = "lightgrey"
 
+    label_attr = config_file_dict["label_attr"]
+    main_fig_nodes_text = \
+        ["<b>%s</b>" % v[label_attr] for v in sample_data_dict.values()]
+
     main_fig_nodes_hovertext = \
         get_main_fig_nodes_hovertext(sample_data_dict,
+                                     main_fig_nodes_text,
+                                     date_list,
+                                     track_list,
                                      config_file_dict["attr_link_list"])
 
     default_xaxis_range = [0.5, len(date_x_vals_dict) + 0.5]
@@ -164,10 +171,6 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     main_fig_attr_link_tips_dict = \
         get_main_fig_attr_link_tips_dict(main_fig_attr_links_dict)
-
-    label_attr = config_file_dict["label_attr"]
-    main_fig_nodes_text = \
-        ["<b>%s</b>" % v[label_attr] for v in sample_data_dict.values()]
 
     if selected_samples:
         ss = selected_samples
@@ -1004,8 +1007,9 @@ def get_main_fig_nodes_y_dict(sample_data_dict, date_attr,
     return main_fig_nodes_y_dict
 
 
-def get_main_fig_nodes_hovertext(sample_data_dict, attr_link_list):
-    """Get hovertext for nodes in main fig.
+def get_main_fig_nodes_hovertext(sample_data_dict, main_fig_nodes_text,
+                                 date_list, track_list, attr_link_list):
+    """Get hovertext for nodes in main fig.TODO
 
     :param sample_data_dict: Sample file data parsed into dict obj
     :type sample_data_dict: dict
@@ -1016,9 +1020,12 @@ def get_main_fig_nodes_hovertext(sample_data_dict, attr_link_list):
     :rtype: list[str]
     """
     ret = []
-    for sample in sample_data_dict:
+    for i, sample in enumerate(sample_data_dict):
         sample_data = sample_data_dict[sample]
-        sample_label_vals = []
+        sample_label_vals = [main_fig_nodes_text[i],
+                             date_list[i],
+                             str(track_list[i]),
+                             ""]
         for attr in attr_link_list:
             if attr[0] == "(" and attr[-1] == ")":
                 attr_list = attr[1:-1].split(";")

--- a/data_parser.py
+++ b/data_parser.py
@@ -1,4 +1,4 @@
-"""Parses sample file for data used in viz."""
+"""Parses sample file for data used in viz.TODO range stuff look everywhere"""
 
 from base64 import b64decode
 from collections import Counter

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -219,10 +219,29 @@ def get_main_fig_secondary_facet_lines(app_data):
     return lines
 
 
-def get_main_fig(app_data, nodes_graph,attr_link_graphs,
+def get_main_fig(app_data, nodes_graph, attr_link_graphs,
                  attr_link_label_graphs, primary_facet_lines_graph,
                  secondary_facet_lines_graph):
-    """TODO"""
+    """Get main fig in viz.
+
+    :param app_data: ``data_parser.get_app_data`` ret val
+    :type app_data: dict
+    :param nodes_graph: Plotly scatter obj of nodes in main fig
+    :type nodes_graph: go.Scatter
+    :param attr_link_graphs: Plotly scatter objs of links in main fig
+    :type attr_link_graphs: list[go.Scatter]
+    :param attr_link_label_graphs: Plotly scatter objs of link labels in main
+        fig.
+    :type attr_link_label_graphs: list[go.Scatter]
+    :param primary_facet_lines_graph: Plotly scatter obj used to draw primary
+        facet lines in main fig.
+    :type primary_facet_lines_graph: go.Scatter
+    :param secondary_facet_lines_graph: Plotly scatter obj used to draw
+        secondary facet lines in main fig.
+    :type secondary_facet_lines_graph: go.Scatter
+    :return: Plotly figure obj showing main fig in viz
+    :rtype: go.Figure
+    """
     ret = go.Figure(
         data=attr_link_graphs + attr_link_label_graphs + [
               nodes_graph,
@@ -263,7 +282,17 @@ def get_main_fig(app_data, nodes_graph,attr_link_graphs,
 
 
 def get_zoomed_out_main_fig(app_data, nodes_graph, attr_link_graphs):
-    """TODO"""
+    """Get zoomed out main fig in viz.
+
+    :param app_data: ``data_parser.get_app_data`` ret val
+    :type app_data: dict
+    :param nodes_graph: Plotly scatter obj of nodes in main fig
+    :type nodes_graph: go.Scatter
+    :param attr_link_graphs: Plotly scatter objs of links in main fig
+    :type attr_link_graphs: list[go.Scatter]
+    :return: Plotly figure obj showing zoomed-out main fig in viz
+    :rtype: go.Figure
+    """
     ret = go.Figure(
         data=attr_link_graphs + [nodes_graph],
         layout={
@@ -298,12 +327,13 @@ def get_zoomed_out_main_fig(app_data, nodes_graph, attr_link_graphs):
 
 
 def get_main_figs(app_data):
-    """Get main fig in viz.TODO
+    """Get main and zoomed-out main figs in viz.
 
     :param app_data: ``data_parser.get_app_data`` ret val
     :type app_data: dict
-    :return: Plotly figure object that shows main fig in viz
-    :rtype: go.Figure
+    :return: Plotly figure objects that show main and zoomed-out main
+        figs in viz.
+    :rtype: tuple[go.Figure, go.Figure]
     """
     nodes_graph = get_main_fig_nodes(app_data)
     attr_link_graphs = get_main_fig_attr_link_graphs(app_data)

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -236,6 +236,7 @@ def get_main_fig(app_data, nodes_graph,attr_link_graphs,
             "showlegend": False,
             "xaxis": {
                 "range": app_data["main_fig_xaxis_range"],
+                "fixedrange": True,
                 "tickmode": "array",
                 "tickvals": app_data["main_fig_xaxis_tickvals"],
                 "ticktext": app_data["main_fig_xaxis_ticktext"],
@@ -246,6 +247,7 @@ def get_main_fig(app_data, nodes_graph,attr_link_graphs,
             },
             "yaxis": {
                 "range": app_data["main_fig_yaxis_range"],
+                "fixedrange": True,
                 "tickmode": "array",
                 "tickvals": app_data["main_fig_yaxis_tickvals"],
                 "ticktext": app_data["main_fig_yaxis_ticktext"],
@@ -271,12 +273,14 @@ def get_zoomed_out_main_fig(app_data, nodes_graph, attr_link_graphs):
             "showlegend": False,
             "xaxis": {
                 "range": app_data["main_fig_xaxis_range"],
+                "fixedrange": True,
                 "tickmode": "array",
                 "tickvals": app_data["main_fig_xaxis_tickvals"],
                 "visible": False
             },
             "yaxis": {
                 "range": app_data["main_fig_yaxis_range"],
+                "fixedrange": True,
                 "tickmode": "array",
                 "tickvals": app_data["main_fig_yaxis_tickvals"],
                 "visible": False

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -219,25 +219,15 @@ def get_main_fig_secondary_facet_lines(app_data):
     return lines
 
 
-def get_main_fig(app_data):
-    """Get main fig in viz.
-
-    :param app_data: ``data_parser.get_app_data`` ret val
-    :type app_data: dict
-    :return: Plotly figure object that shows main fig in viz
-    :rtype: go.Figure
-    """
-    main_fig_attr_link_graphs = get_main_fig_attr_link_graphs(app_data)
-    # TODO decide what to do with these
-    # main_fig_attr_link_tip_graphs = \
-    #     get_main_fig_attr_link_tip_graphs(app_data)
-    main_fig_attr_link_label_graphs = \
-        get_main_fig_attr_link_label_graphs(app_data)
-    fig = go.Figure(
-        data=main_fig_attr_link_graphs + main_fig_attr_link_label_graphs + [
-            get_main_fig_nodes(app_data),
-            get_main_fig_secondary_facet_lines(app_data),
-            get_main_fig_primary_facet_lines(app_data)
+def get_main_fig(app_data, nodes_graph,attr_link_graphs,
+                 attr_link_label_graphs, primary_facet_lines_graph,
+                 secondary_facet_lines_graph):
+    """TODO"""
+    ret = go.Figure(
+        data=attr_link_graphs + attr_link_label_graphs + [
+              nodes_graph,
+              secondary_facet_lines_graph,
+              primary_facet_lines_graph
         ],
         layout={
             "margin": {
@@ -267,4 +257,64 @@ def get_main_fig(app_data):
             "plot_bgcolor": "white"
         },
     )
-    return fig
+    return ret
+
+
+def get_zoomed_out_main_fig(app_data, nodes_graph, attr_link_graphs):
+    """TODO"""
+    ret = go.Figure(
+        data=attr_link_graphs + [nodes_graph],
+        layout={
+            "margin": {
+                "l": 0, "r": 0, "t": 0, "b": 0
+            },
+            "showlegend": False,
+            "xaxis": {
+                "range": app_data["main_fig_xaxis_range"],
+                "tickmode": "array",
+                "tickvals": app_data["main_fig_xaxis_tickvals"],
+                "visible": False
+            },
+            "yaxis": {
+                "range": app_data["main_fig_yaxis_range"],
+                "tickmode": "array",
+                "tickvals": app_data["main_fig_yaxis_tickvals"],
+                "visible": False
+            },
+            "plot_bgcolor": "white"
+        },
+    )
+
+    ret.update_traces(marker_size=8)
+    ret.update_traces(mode="markers",
+                      selector={"mode": "markers+text"})
+    ret.update_traces(line_width=1)
+
+    return ret
+
+
+def get_main_figs(app_data):
+    """Get main fig in viz.TODO
+
+    :param app_data: ``data_parser.get_app_data`` ret val
+    :type app_data: dict
+    :return: Plotly figure object that shows main fig in viz
+    :rtype: go.Figure
+    """
+    nodes_graph = get_main_fig_nodes(app_data)
+    attr_link_graphs = get_main_fig_attr_link_graphs(app_data)
+    attr_link_label_graphs = get_main_fig_attr_link_label_graphs(app_data)
+    primary_facet_lines_graph = get_main_fig_primary_facet_lines(app_data)
+    secondary_facet_lines_graph = get_main_fig_secondary_facet_lines(app_data)
+
+    main_fig = get_main_fig(app_data,
+                            nodes_graph,
+                            attr_link_graphs,
+                            attr_link_label_graphs,
+                            primary_facet_lines_graph,
+                            secondary_facet_lines_graph)
+    zoomed_out_main_fig = get_zoomed_out_main_fig(app_data,
+                                                  nodes_graph,
+                                                  attr_link_graphs)
+
+    return main_fig, zoomed_out_main_fig


### PR DESCRIPTION
Clicking a node on the zoomed-out version scrolls to the corresponding node in the non-zoomed-out version.

Added more information to hover to compensate for lack of axis and node labels in zoomed-out version.

Removed zooming and panning in non-zoomed-out version.