### PR TITLE
Major config changes

### DIFF
--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -2,18 +2,22 @@
   "delimiter": "\t",
   "node_id": "patient_id",
   "y_axes": [
-    "subtree",
-    "location"
+    ["subtree"],
+    ["location"]
   ],
   "date_attr": "date",
   "date_input": "%b %d %Y",
   "date_output": "%d-%m-%Y",
-  "label_attr": "patient_id",
-  "attr_link_list": [
-    "family"
-  ],
-  "node_color_attr": "",
-  "node_symbol_attr": "role",
+  "label_attr": ["patient_id"],
+  "links_config": {
+    "same family": {
+      "all_eq": ["family"],
+      "all_neq": [],
+      "any_eq": []
+    }
+  },
+  "node_color_attr": [],
+  "node_symbol_attr": ["role"],
   "links_across_primary_y": 1,
   "max_day_range": 6000,
   "null_vals": ["n/a"],

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -2,25 +2,33 @@
   "delimiter": "\t",
   "node_id": "sample id",
   "y_axes": [
-    "incompatibility group",
-    "sequence type",
-    "Tn4401 variant"
+    ["incompatibility group"],
+    ["sequence type"],
+    ["Tn4401 variant"]
   ],
   "date_attr": "sample date",
   "date_input": "%B %Y",
   "date_output": "%B %Y",
-  "label_attr": "sample id",
-  "attr_link_list": [
-    "sequence type",
-    "~sequence type;incompatibility group"
-  ],
-  "node_color_attr": "",
-  "node_symbol_attr": "species",
+  "label_attr": ["sample id"],
+  "links_config": {
+    "SNP distance": {
+      "all_eq": ["sequence type"],
+      "all_neq": [],
+      "any_eq": []
+    },
+    "potential plasmid transfer": {
+      "all_eq": ["incompatibility group"],
+      "all_neq": ["sequence type"],
+      "any_eq": []
+    }
+  },
+  "node_color_attr": [],
+  "node_symbol_attr": ["species"],
   "links_across_primary_y": 1,
   "max_day_range": 6000,
   "null_vals": [""],
   "weights": {
-    "sequence type": "@SNV distance@-!SNV distance!"
+    "SNP distance": "@SNV distance@-!SNV distance!"
   },
   "weight_filters": {
     "not_equal": {},

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -2,22 +2,42 @@
   "delimiter": ",",
   "node_id": "Sample ID / Isolate",
   "y_axes": [
-    "Location",
-    "rep_type(s)"
+    ["Location"],
+    ["rep_type(s)"]
   ],
   "date_attr": "Date of collection",
   "date_input": "%B %Y",
   "date_output": "%B %Y",
-  "label_attr": "Patient ID",
-  "attr_link_list": [
-    "F1: MLST type",
-    "Resitance gene type",
-    "SNPs_homozygous",
-    "Left_flanks;Right_flanks",
-    "mash_neighbor_cluster"
-  ],
-  "node_color_attr": "mash_neighbor_cluster",
-  "node_symbol_attr": "Organism",
+  "label_attr": ["Patient ID"],
+  "links_config": {
+    "F1: MLST type": {
+      "all_eq": ["F1: MLST type"],
+      "all_neq": [],
+      "any_eq": []
+    },
+    "Resitance gene type": {
+      "all_eq": ["Resitance gene type"],
+      "all_neq": [],
+      "any_eq": []
+    },
+    "SNPs_homozygous": {
+      "all_eq": ["SNPs_homozygous"],
+      "all_neq": [],
+      "any_eq": []
+    },
+    "Left_flanks;Right_flanks": {
+      "all_eq": ["Left_flanks", "Right_flanks"],
+      "all_neq": [],
+      "any_eq": []
+    },
+    "mash_neighbor_cluster": {
+      "all_eq": ["mash_neighbor_cluster"],
+      "all_neq": [],
+      "any_eq": []
+    }
+  },
+  "node_color_attr": ["mash_neighbor_cluster"],
+  "node_symbol_attr": ["Organism"],
   "links_across_primary_y": 0,
   "max_day_range": 60,
   "null_vals": ["", "-"],

--- a/config_files/senterica_clusters_07042022_config.json
+++ b/config_files/senterica_clusters_07042022_config.json
@@ -22,17 +22,14 @@
   "max_day_range": 14,
   "null_vals": ["", "-", "NA"],
   "weights": {
-    "threshold_10;collection_date": "@snp_dist@-!snp_dist!",
     "same cluster": "@snp_dist@-!snp_dist!"
   },
   "weight_filters": {
     "not_equal": {},
     "less_than": {
-      "threshold_10;collection_date": -5,
       "same cluster": -5
     },
     "greater_than": {
-      "threshold_10;collection_date": 5,
       "same cluster": 5
     }
   },

--- a/config_files/senterica_clusters_07042022_config.json
+++ b/config_files/senterica_clusters_07042022_config.json
@@ -2,34 +2,38 @@
   "delimiter": "\t",
   "node_id": "Sample",
   "y_axes": [
-    "threshold_10",
-    "site_order"
+    ["threshold_10"],
+    ["site_order"]
   ],
   "date_attr": "collection_date",
   "date_input": "%Y-%m-%d %H:%M:%S",
   "date_output": "%Y-%m-%d",
-  "label_attr": "Sample",
-  "attr_link_list": [
-    "threshold_10"
-  ],
-  "node_color_attr": "serovar",
-  "node_symbol_attr": "serovar",
+  "label_attr": ["Sample"],
+  "links_config": {
+    "same cluster": {
+      "all_eq": ["threshold_10"],
+      "all_neq": [],
+      "any_eq": []
+    }
+  },
+  "node_color_attr": ["serovar"],
+  "node_symbol_attr": ["serovar"],
   "links_across_primary_y": "True",
   "max_day_range": 14,
   "null_vals": ["", "-", "NA"],
   "weights": {
     "threshold_10;collection_date": "@snp_dist@-!snp_dist!",
-    "threshold_10": "@snp_dist@-!snp_dist!"
+    "same cluster": "@snp_dist@-!snp_dist!"
   },
   "weight_filters": {
     "not_equal": {},
     "less_than": {
       "threshold_10;collection_date": -5,
-      "threshold_10": -5
+      "same cluster": -5
     },
     "greater_than": {
       "threshold_10;collection_date": 5,
-      "threshold_10": 5
+      "same cluster": 5
     }
   },
   "attr_val_filters": {}

--- a/data_parser.py
+++ b/data_parser.py
@@ -135,9 +135,9 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         attr_val_filters=config_file_dict["attr_val_filters"]
     )
 
-    attr_link_color_dict = get_attr_link_color_dict(sample_links_dict)
+    link_color_dict = get_link_color_dict(sample_links_dict)
 
-    main_fig_attr_links_dict = get_main_fig_attr_links_dict(
+    main_fig_links_dict = get_main_fig_links_dict(
         sample_links_dict=sample_links_dict,
         main_fig_nodes_x_dict=main_fig_nodes_x_dict,
         main_fig_nodes_y_dict=main_fig_nodes_y_dict,
@@ -146,7 +146,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         main_fig_width=main_fig_width
     )
 
-    main_fig_attr_link_labels_dict = get_main_fig_attr_link_labels_dict(
+    main_fig_link_labels_dict = get_main_fig_link_labels_dict(
         sample_links_dict=sample_links_dict,
         main_fig_nodes_x_dict=main_fig_nodes_x_dict,
         main_fig_nodes_y_dict=main_fig_nodes_y_dict,
@@ -201,9 +201,9 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
         "main_fig_nodes_hovertext":
             main_fig_nodes_hovertext,
         "node_color_attr_dict": node_color_attr_dict,
-        "main_fig_attr_links_dict": main_fig_attr_links_dict,
-        "main_fig_attr_link_labels_dict": main_fig_attr_link_labels_dict,
-        "attr_link_color_dict": attr_link_color_dict,
+        "main_fig_links_dict": main_fig_links_dict,
+        "main_fig_link_labels_dict": main_fig_link_labels_dict,
+        "link_color_dict": link_color_dict,
         "main_fig_primary_facet_x":
             get_main_fig_primary_facet_x(xaxis_range, num_of_primary_facets),
         "main_fig_primary_facet_y":
@@ -562,7 +562,7 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
     return sample_links_dict
 
 
-def get_attr_link_color_dict(sample_links_dict):
+def get_link_color_dict(sample_links_dict):
     """Get dict assigning color to attrs vized as links.
 
     # TODO: color blind safe? Color/pattern combos get confusing
@@ -573,24 +573,24 @@ def get_attr_link_color_dict(sample_links_dict):
         as vals.
     :rtype: dict
     """
-    available_attr_link_color_list = [
+    available_link_color_list = [
         (228, 26, 28),
         (55, 126, 184),
         (77, 175, 74),
         (152, 78, 163),
         (255, 127, 0)
     ]
-    if len(sample_links_dict) > len(available_attr_link_color_list):
+    if len(sample_links_dict) > len(available_link_color_list):
         msg = "Not enough unique colors for different attributes"
         raise IndexError(msg)
-    zip_obj = zip(sample_links_dict.keys(), available_attr_link_color_list)
+    zip_obj = zip(sample_links_dict.keys(), available_link_color_list)
     ret = {k: v for (k, v) in zip_obj}
     return ret
 
 
-def get_main_fig_attr_links_dict(sample_links_dict, main_fig_nodes_x_dict,
-                                 main_fig_nodes_y_dict, selected_samples,
-                                 main_fig_height, main_fig_width):
+def get_main_fig_links_dict(sample_links_dict, main_fig_nodes_x_dict,
+                            main_fig_nodes_y_dict, selected_samples,
+                            main_fig_height, main_fig_width):
     """Get dict with info used by Plotly to viz links in main graph.
 
     :param sample_links_dict: ``get_sample_links_dict`` ret val
@@ -665,11 +665,9 @@ def get_main_fig_attr_links_dict(sample_links_dict, main_fig_nodes_x_dict,
     return ret
 
 
-def get_main_fig_attr_link_labels_dict(sample_links_dict,
-                                       main_fig_nodes_x_dict,
-                                       main_fig_nodes_y_dict, selected_samples,
-                                       main_fig_height, main_fig_width,
-                                       weights):
+def get_main_fig_link_labels_dict(sample_links_dict, main_fig_nodes_x_dict,
+                                  main_fig_nodes_y_dict, selected_samples,
+                                  main_fig_height, main_fig_width, weights):
     """Get dict with info used by Plotly to viz link labels.
 
     TODO: there may be a better way to do this. Certainly, the code

--- a/data_parser.py
+++ b/data_parser.py
@@ -423,20 +423,22 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
                           weight_filters, attr_val_filters):
     """Get a dict of all links to viz in main graph.
 
-    The keys in the dict are different attrs. The values are a nested
-    dict. The keys in the nested dict are tuples containing two samples
-    with a shared val for the attr key in the outer dict. The values in
-    the nested dict are weights assigned to that link.
+    The keys in the dict are different link labels. The values are a
+    nested dict. The keys in the nested dict are tuples containing two
+    samples that satisfy the criteria for that link b/w them. The
+    values in the nested dict are weights assigned to the link b/w
+    these nodes.
 
     We filter out certain links using ``weight_filters`` and
     ``attr_val_filters``.
 
     :param sample_data_dict: ``get_sample_data_dict`` ret val
     :type sample_data_dict: dict
-    :param attr_link_list: list of attrs to include in ret dict
-    :type attr_link_list: list[str]
-    :param primary_y: attr encoded as one part of a track along y-axis
-    :type primary_y: str
+    :param links_config: dict of criteria for different user-specified
+        links.
+    :type links_config: dict
+    :param primary_y: First list specified by user in y-axes
+    :type primary_y: list[str]
     :param links_across_primary_y: Whether we consider links across
         different primary y vals.
     :type links_across_primary_y: bool
@@ -445,8 +447,11 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
     :param weights: Dictionary of expressions used to assign weights to
         specific attr links
     :type weights: dict
+    :param weight_filters: Dictionary of criteria for filtering out
+        certain links by weight.
+    :type weight_filters: dict
     :param attr_val_filters: Dictionary of vals to ignore for certain
-        attrs, when generating links.
+        link labels, when generating links b/w nodes.
     :type attr_val_filters: dict
     :return: Dict detailing links to viz in main graph
     :rtype: dict
@@ -456,7 +461,8 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
     regex_obj = compile("!.*?!|@.*?@")
 
     def get_sample_attr_list(sample_data, link_config_list, filters):
-        """TODO"""
+        # Get the attr values for a sample, corresponding to one of the
+        # lists that forms criteria for a link.
         return [None
                 if (e in filters and filters[e] == sample_data[e])
                 else sample_data[e]
@@ -528,7 +534,7 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
                 )
 
                 # Unfortunately, any(empty list) returns False. So we
-                # need to an intermediate variable.
+                # need an intermediate variable.
                 any_eq_matches = \
                     [i == j and i is not None for (i, j) in any_eq_zip_obj]
                 any_eq = any(any_eq_matches) if len(any_eq_matches) else True
@@ -536,7 +542,9 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
                 if all_eq and all_neq and any_eq:
                     if link_label in weights:
                         def repl_fn(match_obj):
-                            """TODO"""
+                            # Substitute the syntax used in weight
+                            # expressions to reference node attr
+                            # values, with the actual attr value.
                             match = match_obj.group(0)
                             if match[0] == "!":
                                 exp_attr = match.strip("!")
@@ -580,8 +588,6 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
 
 def get_link_color_dict(sample_links_dict):
     """Get dict assigning color to attrs vized as links.
-
-    # TODO: color blind safe? Color/pattern combos get confusing
 
     :param sample_links_dict: ``get_sample_links_dict`` ret val
     :type sample_links_dict: dict

--- a/data_parser.py
+++ b/data_parser.py
@@ -42,14 +42,13 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
                                             config_file_dict["date_input"],
                                             config_file_dict["date_output"],
                                             config_file_dict["null_vals"])
+    sample_data_vals = sample_data_dict.values()
     enumerated_samples = enumerate(sample_data_dict)
     selected_samples = \
         {k for i, k in enumerated_samples if str(i) in selected_nodes}
 
-    date_list =\
-        [v[config_file_dict["date_attr"]] for v in sample_data_dict.values()]
-    datetime_list =\
-        [v["datetime_obj"] for v in sample_data_dict.values()]
+    date_list = [v[config_file_dict["date_attr"]] for v in sample_data_vals]
+    datetime_list = [v["datetime_obj"] for v in sample_data_vals]
     date_x_vals_dict = get_date_x_vals_dict(date_list=date_list,
                                             datetime_list=datetime_list)
     main_fig_nodes_x_dict = \
@@ -80,7 +79,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
     node_symbol_attr = config_file_dict["node_symbol_attr"]
     if node_symbol_attr:
         node_symbol_attr_list = \
-            [v[node_symbol_attr] for v in sample_data_dict.values()]
+            [tuple([v[e] for e in node_symbol_attr]) for v in sample_data_vals]
         node_symbol_attr_dict = \
             get_node_symbol_attr_dict(node_symbol_attr_list)
         main_fig_nodes_marker_symbol = \
@@ -98,8 +97,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     node_color_attr = config_file_dict["node_color_attr"]
     if node_color_attr:
-        node_color_attr_list = \
-            [v[node_color_attr] for v in sample_data_dict.values()]
+        node_color_attr_list = [v[node_color_attr] for v in sample_data_vals]
         node_color_attr_dict = get_node_color_attr_dict(node_color_attr_list)
         main_fig_nodes_marker_color = \
             [node_color_attr_dict[v] for v in node_color_attr_list]
@@ -109,7 +107,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     label_attr = config_file_dict["label_attr"]
     main_fig_nodes_text = \
-        ["<b>%s</b>" % v[label_attr] for v in sample_data_dict.values()]
+        ["<b>%s</b>" % v[label_attr] for v in sample_data_vals]
 
     main_fig_nodes_hovertext = \
         get_main_fig_nodes_hovertext(sample_data_dict,

--- a/data_parser.py
+++ b/data_parser.py
@@ -163,9 +163,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
     else:
         main_fig_nodes_textfont_color = "black"
 
-    main_fig_yaxis_ticktext = \
-        ["<br>".join(["null" if e is None else e for e in k])
-         for k in track_y_vals_dict]
+    main_fig_yaxis_ticktext = get_main_fig_yaxis_ticktext(track_y_vals_dict)
 
     app_data = {
         "node_shape_legend_fig_nodes_y":
@@ -844,6 +842,20 @@ def get_track_y_vals_dict(max_node_count_at_track_dict):
         node_count = max_node_count_at_track_dict[track]
         ret[track] = last_track_top_boundary + 1 + (node_count - 1)/2
         last_track_top_boundary += node_count
+    return ret
+
+
+def get_main_fig_yaxis_ticktext(track_y_vals_dict):
+    """TODO"""
+    ["<br>".join(["; ".join(["null" if k is None else k for k in j]) for j in i]) for i in track_y_vals_dict]
+    ret = []
+    for track in track_y_vals_dict:
+        inner_ret = []
+        for inner_track in track:
+            inner_ret.append(
+                "; ".join(["null" if e is None else e for e in inner_track])
+            )
+        ret.append("<br>".join(inner_ret))
     return ret
 
 

--- a/data_parser.py
+++ b/data_parser.py
@@ -445,7 +445,7 @@ def get_sample_links_dict(sample_data_dict, links_config, primary_y,
     :param max_day_range: Maximum day range to still consider links
     :type max_day_range: int
     :param weights: Dictionary of expressions used to assign weights to
-        specific attr links
+        specific links.
     :type weights: dict
     :param weight_filters: Dictionary of criteria for filtering out
         certain links by weight.
@@ -715,7 +715,7 @@ def get_main_fig_link_labels_dict(sample_links_dict, main_fig_nodes_x_dict,
     :param main_fig_width: Width for main fig
     :type main_fig_width: int
     :param weights: Dictionary of expressions used to assign weights to
-        specific attr links
+        specific links.
     :type weights: dict
     :return: Dict with info used by Plotly to viz links in main graph
     :rtype: dict
@@ -836,7 +836,7 @@ def get_main_fig_nodes_x_dict(sample_data_dict, date_attr, date_list,
 
 
 def get_max_node_count_at_track_dict(track_date_node_count_dict):
-    """Get the max number of nodes at one date in every track.TODO
+    """Get the max number of nodes at one date in every track.
 
     :param track_date_node_count_dict: Number of nodes at each track
         and date combination.
@@ -876,8 +876,16 @@ def get_track_y_vals_dict(max_node_count_at_track_dict):
 
 
 def get_main_fig_yaxis_ticktext(track_y_vals_dict):
-    """TODO"""
-    ["<br>".join(["; ".join(["null" if k is None else k for k in j]) for j in i]) for i in track_y_vals_dict]
+    """Get the ticktext used by Plotly to label the y-axis.
+
+    We map each track to a single str. We join the inner tuples with a
+    linebreak, and the values inside each tuple with a semicolon.
+
+    :param track_y_vals_dict: ``get_track_y_vals_dict`` ret val
+    :type track_y_vals_dict: dict
+    :return: Dict with label corresponding to each possible track
+    :rtype: dict
+    """
     ret = []
     for track in track_y_vals_dict:
         inner_ret = []
@@ -892,20 +900,20 @@ def get_main_fig_yaxis_ticktext(track_y_vals_dict):
 def get_main_fig_nodes_y_dict(sample_data_dict, date_attr, track_list,
                               track_date_node_count_dict,
                               max_node_count_at_track_dict, track_y_vals_dict):
-    """Get dict mapping nodes to y vals.TODO
+    """Get dict mapping nodes to y vals.
 
     :param sample_data_dict: Sample file data parsed into dict obj
     :rtype: dict
     :param date_attr: Sample file attr encoded by sample date/x-axis
     :type date_attr: str
+    :param track_list: List of sample tracks wrt all nodes
+    :type track_list: list[tuple[tuple[str]]]
     :param track_date_node_count_dict: Number of nodes at each track
         and date combination.
     :type track_date_node_count_dict: dict
     :param max_node_count_at_track_dict: Maximum number of nodes at a
         single date within each track.
     :type max_node_count_at_track_dict: dict
-    :param y_axes: List of attrs to use as hierarchical y axes
-    :type y_axes: list[str]
     :param track_y_vals_dict: Dict mapping tracks to numerical y vals
     :type track_y_vals_dict: dict
     :return: Dict mapping nodes to y vals
@@ -942,8 +950,6 @@ def get_main_fig_nodes_hovertext(sample_data_dict, main_fig_nodes_text,
     :type date_list: list
     :param track_list: List of sample tracks wrt all nodes
     :type track_list: list
-    :param attr_link_list: list of attrs to include in ret dict
-    :type attr_link_list: list[str]
     :return: List of d3-formatted text to display on hover across all
         nodes in main fig.
     :rtype: list[str]

--- a/data_parser.py
+++ b/data_parser.py
@@ -1,4 +1,4 @@
-"""Parses sample file for data used in viz.TODO all docstrings for types"""
+"""Parses sample file for data used in viz."""
 
 from base64 import b64decode
 from collections import Counter

--- a/data_parser.py
+++ b/data_parser.py
@@ -1,4 +1,4 @@
-"""Parses sample file for data used in viz."""
+"""Parses sample file for data used in viz.TODO all docstrings for types"""
 
 from base64 import b64decode
 from collections import Counter
@@ -67,9 +67,9 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
     main_fig_nodes_y_dict = get_main_fig_nodes_y_dict(
         sample_data_dict,
         date_attr=config_file_dict["date_attr"],
+        track_list=track_list,
         track_date_node_count_dict=track_date_node_count_dict,
         max_node_count_at_track_dict=max_node_count_at_track_dict,
-        y_axes=config_file_dict["y_axes"],
         track_y_vals_dict=track_y_vals_dict
     )
 
@@ -853,11 +853,10 @@ def get_track_y_vals_dict(max_node_count_at_track_dict):
     return ret
 
 
-def get_main_fig_nodes_y_dict(sample_data_dict, date_attr,
+def get_main_fig_nodes_y_dict(sample_data_dict, date_attr, track_list,
                               track_date_node_count_dict,
-                              max_node_count_at_track_dict, y_axes,
-                              track_y_vals_dict):
-    """Get dict mapping nodes to y vals.
+                              max_node_count_at_track_dict, track_y_vals_dict):
+    """Get dict mapping nodes to y vals.TODO
 
     :param sample_data_dict: Sample file data parsed into dict obj
     :rtype: dict
@@ -880,10 +879,9 @@ def get_main_fig_nodes_y_dict(sample_data_dict, date_attr,
                   for k, v in track_date_node_count_dict.items()}
 
     main_fig_nodes_y_dict = {}
-    for sample in sample_data_dict:
+    for i, sample in enumerate(sample_data_dict):
         sample_date = sample_data_dict[sample][date_attr]
-        sample_track = \
-            tuple((sample_data_dict[sample][axis] for axis in y_axes))
+        sample_track = track_list[i]
         [stagger, multiplier] = helper_obj[(sample_track, sample_date)]
 
         unstaggered_y = track_y_vals_dict[sample_track]

--- a/data_parser.py
+++ b/data_parser.py
@@ -78,6 +78,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     node_symbol_attr = config_file_dict["node_symbol_attr"]
     if node_symbol_attr:
+        # Use tuples instead of lists for hashing
         node_symbol_attr_list = \
             [tuple([v[e] for e in node_symbol_attr]) for v in sample_data_vals]
         node_symbol_attr_dict = \
@@ -97,6 +98,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     node_color_attr = config_file_dict["node_color_attr"]
     if node_color_attr:
+        # Use tuples instead of lists for hashing
         node_color_attr_list = \
             [tuple([v[e] for e in node_color_attr]) for v in sample_data_vals]
         node_color_attr_dict = get_node_color_attr_dict(node_color_attr_list)
@@ -278,8 +280,8 @@ def sorting_key(track):
     * Sort ints next
     * Sort strs last
 
-    :param track: List of attr vals found in a track
-    :type track: tuple[str]
+    :param track: Track value for a node
+    :type track: tuple[tuple[str]]
     :return: List of tuples mapped to each attr val in track
     :rtype: list[list[tuple]]
     """
@@ -351,7 +353,7 @@ def get_node_symbol_attr_dict(node_symbol_attr_list):
 
     :param node_symbol_attr_list: List of node symbol attr vals across
         all nodes.
-    :type node_symbol_attr_list: list[str]
+    :type node_symbol_attr_list: list[tuple[str]]
     :return: dict with unique node symbol attr vals as keys, and actual
         symbols as vals.
     :rtype: dict
@@ -380,7 +382,7 @@ def get_node_color_attr_dict(node_color_attr_list):
 
     :param node_color_attr_list: List of node color attr vals across
         all nodes.
-    :type node_color_attr_list: list[str]
+    :type node_color_attr_list: list[tuple[str]]
     :return: dict with unique node color attr vals as keys, and actual
         colors as vals.
     :rtype: dict
@@ -388,7 +390,6 @@ def get_node_color_attr_dict(node_color_attr_list):
     node_color_attr_dict = {}
     node_color_attr_table = dict.fromkeys(node_color_attr_list)
 
-    # TODO make color blind safe by using color + pattern
     available_colors = [
         "#8dd3c7",
         "#ffffb3",

--- a/legend_fig_generator.py
+++ b/legend_fig_generator.py
@@ -76,8 +76,8 @@ def get_link_legend_fig_links(app_data):
     :rtype: list[go.Scatter]
     """
     links = []
-    for i, attr in enumerate(app_data["main_fig_attr_links_dict"]):
-        (r, g, b) = app_data["attr_link_color_dict"][attr]
+    for i, attr in enumerate(app_data["main_fig_links_dict"]):
+        (r, g, b) = app_data["link_color_dict"][attr]
         links.append(
             go.Scatter(
                 x=[0, 1],
@@ -120,7 +120,7 @@ def get_link_legend_fig(app_data):
             "yaxis": {
                 "visible": False,
                 "fixedrange": True,
-                "range": [len(app_data["main_fig_attr_links_dict"]), -0.5]
+                "range": [len(app_data["main_fig_links_dict"]), -0.5]
             },
             "showlegend": False,
             "plot_bgcolor": "white"

--- a/legend_fig_generator.py
+++ b/legend_fig_generator.py
@@ -78,10 +78,6 @@ def get_link_legend_fig_links(app_data):
     links = []
     for i, attr in enumerate(app_data["main_fig_attr_links_dict"]):
         (r, g, b) = app_data["attr_link_color_dict"][attr]
-        if attr in app_data["main_fig_attr_link_labels_dict"]:
-            label = attr + " (weighted)"
-        else:
-            label = attr
         links.append(
             go.Scatter(
                 x=[0, 1],
@@ -91,7 +87,7 @@ def get_link_legend_fig_links(app_data):
                     "width": 3,
                     "color": "rgb(%s, %s, %s)" % (r, g, b)
                 },
-                text=["<b>%s</b>" % label, None],
+                text=["<b>%s</b>" % attr, None],
                 textfont={
                     "color": "black",
                     "size": 16

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -36,7 +36,7 @@ def get_main_fig_nodes(app_data):
     return nodes
 
 
-def get_main_fig_attr_link_graphs(app_data):
+def get_main_fig_link_graphs(app_data):
     """Get plotly scatter objs of links in main fig.
 
     This is basically a list of different scatter objs--one for each
@@ -48,10 +48,10 @@ def get_main_fig_attr_link_graphs(app_data):
     :rtype: list[go.Scatter]
     """
     ret = []
-    for attr in app_data["main_fig_attr_links_dict"]:
-        attr_x = app_data["main_fig_attr_links_dict"][attr]["x"]
-        attr_y = app_data["main_fig_attr_links_dict"][attr]["y"]
-        (r, g, b) = app_data["attr_link_color_dict"][attr]
+    for attr in app_data["main_fig_links_dict"]:
+        attr_x = app_data["main_fig_links_dict"][attr]["x"]
+        attr_y = app_data["main_fig_links_dict"][attr]["y"]
+        (r, g, b) = app_data["link_color_dict"][attr]
 
         attr_graph = go.Scatter(
             x=[x if x else None for x in attr_x],
@@ -67,7 +67,7 @@ def get_main_fig_attr_link_graphs(app_data):
     return ret
 
 
-def get_main_fig_attr_link_label_graphs(app_data):
+def get_main_fig_link_label_graphs(app_data):
     """Get plotly scatter objs of links labels in main fig.
 
     This is basically a list of different scatter objs--one for each
@@ -79,11 +79,11 @@ def get_main_fig_attr_link_label_graphs(app_data):
     :rtype: list[go.Scatter]
     """
     ret = []
-    for attr in app_data["main_fig_attr_link_labels_dict"]:
-        attr_x = app_data["main_fig_attr_link_labels_dict"][attr]["x"]
-        attr_y = app_data["main_fig_attr_link_labels_dict"][attr]["y"]
-        attr_text = app_data["main_fig_attr_link_labels_dict"][attr]["text"]
-        (r, g, b) = app_data["attr_link_color_dict"][attr]
+    for attr in app_data["main_fig_link_labels_dict"]:
+        attr_x = app_data["main_fig_link_labels_dict"][attr]["x"]
+        attr_y = app_data["main_fig_link_labels_dict"][attr]["y"]
+        attr_text = app_data["main_fig_link_labels_dict"][attr]["text"]
+        (r, g, b) = app_data["link_color_dict"][attr]
 
         attr_graph = go.Scatter(
             x=attr_x,
@@ -269,20 +269,20 @@ def get_main_figs(app_data):
     :rtype: tuple[go.Figure, go.Figure]
     """
     nodes_graph = get_main_fig_nodes(app_data)
-    attr_link_graphs = get_main_fig_attr_link_graphs(app_data)
-    attr_link_label_graphs = get_main_fig_attr_link_label_graphs(app_data)
+    link_graphs = get_main_fig_link_graphs(app_data)
+    link_label_graphs = get_main_fig_link_label_graphs(app_data)
     primary_facet_lines_graph = get_main_fig_primary_facet_lines(app_data)
     secondary_facet_lines_graph = get_main_fig_secondary_facet_lines(app_data)
 
     main_fig = get_main_fig(app_data,
                             nodes_graph,
-                            attr_link_graphs,
-                            attr_link_label_graphs,
+                            link_graphs,
+                            link_label_graphs,
                             primary_facet_lines_graph,
                             secondary_facet_lines_graph)
     zoomed_out_main_fig = get_zoomed_out_main_fig(app_data,
                                                   nodes_graph,
-                                                  attr_link_graphs,
+                                                  link_graphs,
                                                   primary_facet_lines_graph)
 
     return main_fig, zoomed_out_main_fig


### PR DESCRIPTION
Multiple fields now allow a list of attributes, instead of just one attribute. Basically, users can now use a combination of multiple attributes to specify some visual encodings that were originally only specifiable by one attribute.

List of config fields that originally expected a str val, but not expect a list val:

* ``"label_attr"``
* ``"node_color_attr"``
* ``"node_symbol_attr"``

In addition, ``"y_axes"`` now expects a list of lists, instead of a list. This is a bit redundant, because you could achieve the same level of organization by sticking to a list, but it sometimes save space on the y-axis.

``"attr_link_list"`` underwent major changes. It is now called ``"links_config"``, and instead of expecting a list val, it expected a dict. The dict has the following format:

```json
"links_config": {
  "link_label_1": {
    "all_eq": ["foo", "bar"],
    "all_neq": ["ham"],
    "any_eq": ["spam", "eggs"]
  },
  "link_label_2": {
    "all_eq": ["cat"],
    "all_neq": ["dog"],
    "any_eq": []
  }
}
```

We have removed the syntax of specifying disjoint vals, and overlapping vals. Instead, we are using explicit field specifications to do this, which are much less error-prone, less confusing, and more machine readable imo.

In the above example, we would draw ``"link_label_1"`` links b/w any two nodes that:

* Had the same vals for the "foo" and "bar" attributes
* Had different vals for the "ham" attribute
* Had any overlapping vals for the "spam" or "eggs" attributes

We would draw ``"link_label_2"`` links b/w any two nodes that:

* Had the same val for the "cat" attribute
* Had different vals for the "dog" attribute

In the legend to the right, the links would be labeled with ``"link_label_1"`` and ``"link_label_2"``, instead of the criteria used to generate the links (as we did before).