### PR TITLE
Reimplement zoom

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from sys import maxsize
 
 import dash
 from dash import Dash
+from dash.dash import no_update
 from dash.dependencies import (ClientsideFunction,
                                Input,
                                Output,
@@ -19,6 +20,7 @@ from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 from dash_html_components import Div
+import plotly.graph_objects as go
 
 from data_parser import get_app_data, parse_fields_from_example_file
 from main_fig_generator import (get_main_fig,
@@ -100,7 +102,8 @@ def launch_app(_):
                                         dcc.Graph(
                                             figure={},
                                             id="main-graph",
-                                            config={"displayModeBar": False},
+                                            config={"displayModeBar": False,
+                                                    "scrollZoom": True},
                                             style={"height": "100%",
                                                    "width": "100%"}
                                         ),
@@ -940,11 +943,15 @@ def select_nodes(click_data, selected_nodes):
 @app.callback(
     inputs=[
         Input("selected-nodes", "data"),
-        Input("viz-btn", "n_clicks")
+        Input("viz-btn", "n_clicks"),
+        Input("main-graph", "relayoutData")
     ],
     state=[
         State("upload-sample-file", "contents"),
-        State("upload-config-file", "contents")
+        State("upload-config-file", "contents"),
+        State("main-graph", "figure"),
+        State("main-graph-x-axis", "figure"),
+        State("main-graph-y-axis", "figure")
     ],
     output=[
         Output("main-graph", "figure"),
@@ -960,9 +967,10 @@ def select_nodes(click_data, selected_nodes):
     ],
     prevent_initial_call=True
 )
-def update_main_viz(selected_nodes, _, sample_file_contents,
-                    config_file_contents):
-    """Update main graph, axes, zoomed-out main graph, and legends.
+def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
+                    config_file_contents, old_main_fig, old_main_fig_x_axis,
+                    old_main_fig_y_axis):
+    """Update main graph, axes, zoomed-out main graph, and legends.TODO
 
     Current triggers:
 
@@ -1005,6 +1013,49 @@ def update_main_viz(selected_nodes, _, sample_file_contents,
                                            vpsc=True)
         main_fig = get_main_fig(app_data)
         zoomed_out_main_fig = get_zoomed_out_main_fig(zoomed_out_app_data)
+    elif trigger == "main-graph.relayoutData":
+        zoom_keys = ["xaxis.range[0]",
+                     "xaxis.range[1]",
+                     "yaxis.range[0]",
+                     "yaxis.range[1]"]
+        if not all([e in relayout_data for e in zoom_keys]):
+            raise PreventUpdate
+
+        main_fig = go.Figure(old_main_fig)
+        main_fig_x_axis = go.Figure(old_main_fig_x_axis)
+        main_fig_y_axis = go.Figure(old_main_fig_y_axis)
+
+        old_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
+        new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
+        new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
+        # Should be about equal across x and y
+        change_in_range = new_x_axis_range[1] - new_x_axis_range[0]
+        change_in_range /= (old_x_axis_range[1] - old_x_axis_range[0])
+
+        main_fig_nodes_trace = \
+            [e for e in old_main_fig["data"]
+             if "name" in e and e["name"] == "main_fig_nodes_trace"][0]
+        old_marker_size = main_fig_nodes_trace["marker"]["size"]
+        new_marker_size = old_marker_size / change_in_range
+        old_textfont_size = main_fig_nodes_trace["textfont"]["size"]
+        new_textfont_size = old_textfont_size / change_in_range
+
+        main_fig.update_traces(marker={"size": new_marker_size},
+                               textfont={"size": new_textfont_size},
+                               selector={"name": "main_fig_nodes_trace"})
+        main_fig_x_axis.update_layout(xaxis={"range": new_x_axis_range})
+        main_fig_y_axis.update_layout(yaxis={"range": new_y_axis_range})
+
+        return (main_fig,
+                no_update,
+                main_fig_x_axis,
+                no_update,
+                main_fig_y_axis,
+                no_update,
+                no_update,
+                no_update,
+                no_update,
+                no_update)
     else:
         msg = "Unexpected trigger trying to update main graph: %s" % trigger
         raise RuntimeError(msg)

--- a/app.py
+++ b/app.py
@@ -1025,21 +1025,31 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
         if not zoom_event and not autorange_event:
             raise PreventUpdate
 
-        main_fig = go.Figure(old_main_fig)
-        main_fig_x_axis = go.Figure(old_main_fig_x_axis)
-        main_fig_y_axis = go.Figure(old_main_fig_y_axis)
+        first_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
+        first_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
+        previous_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
 
-        old_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
         if zoom_event:
             new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
             new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
         else:
-            new_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
-            new_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
+            new_x_axis_range = first_x_axis_range
+            new_y_axis_range = first_y_axis_range
 
         # Should be about equal across x and y
-        change_in_range = new_x_axis_range[1] - new_x_axis_range[0]
-        change_in_range /= (old_x_axis_range[1] - old_x_axis_range[0])
+        change_in_range = new_x_axis_range[1]-new_x_axis_range[0]
+        overall_change_in_range = change_in_range
+        change_in_range /= \
+            (previous_x_axis_range[1]-previous_x_axis_range[0])
+        overall_change_in_range /= \
+            (first_x_axis_range[1]-first_x_axis_range[0])
+
+        if overall_change_in_range < 1 or overall_change_in_range > 5:
+            raise PreventUpdate
+
+        main_fig = go.Figure(old_main_fig)
+        main_fig_x_axis = go.Figure(old_main_fig_x_axis)
+        main_fig_y_axis = go.Figure(old_main_fig_y_axis)
 
         main_fig_nodes_trace = \
             [e for e in old_main_fig["data"]

--- a/app.py
+++ b/app.py
@@ -1029,25 +1029,29 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
         main_fig_x_axis = go.Figure(old_main_fig_x_axis)
         main_fig_y_axis = go.Figure(old_main_fig_y_axis)
 
+        first_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
+        first_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
         old_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
+
         if zoom_event:
             new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
             new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
         else:
-            new_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
-            new_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
+            new_x_axis_range = first_x_axis_range
+            new_y_axis_range = first_y_axis_range
 
         # Should be about equal across x and y
         change_in_range = new_x_axis_range[1] - new_x_axis_range[0]
-        change_in_range /= (old_x_axis_range[1] - old_x_axis_range[0])
+        change_in_range /= (first_x_axis_range[1] - first_x_axis_range[0])
 
+        # TODO do not used hardcoded values
         main_fig_nodes_trace = \
             [e for e in old_main_fig["data"]
              if "name" in e and e["name"] == "main_fig_nodes_trace"][0]
         old_marker_size = main_fig_nodes_trace["marker"]["size"]
-        new_marker_size = old_marker_size / change_in_range
+        new_marker_size = max(1, 24/change_in_range)
         old_textfont_size = main_fig_nodes_trace["textfont"]["size"]
-        new_textfont_size = old_textfont_size / change_in_range
+        new_textfont_size = max(1, 16/change_in_range)
 
         main_fig.update_traces(marker={"size": new_marker_size},
                                textfont={"size": new_textfont_size},

--- a/app.py
+++ b/app.py
@@ -1043,6 +1043,17 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
         main_fig.update_traces(marker={"size": new_marker_size},
                                textfont={"size": new_textfont_size},
                                selector={"name": "main_fig_nodes_trace"})
+        main_fig_x_axis.update_traces(textfont={"size": new_textfont_size},
+                                      selector={
+                                          "name": "main_fig_x_axis_trace"
+                                      })
+        main_fig_y_axis.update_traces(textfont={"size": new_textfont_size},
+                                      selector={
+                                          "name": "main_fig_y_axis_trace"
+                                      })
+
+        main_fig.update_layout(xaxis={"range": new_x_axis_range},
+                               yaxis={"range": new_y_axis_range})
         main_fig_x_axis.update_layout(xaxis={"range": new_x_axis_range})
         main_fig_y_axis.update_layout(yaxis={"range": new_y_axis_range})
 

--- a/app.py
+++ b/app.py
@@ -95,7 +95,7 @@ def launch_app(_):
                                         className="p-0",
                                         style={"height": "80vh",
                                                "width": "10vw",
-                                               "overflow": "hidden"},
+                                               "overflowY": "scroll"},
                                         width=2
                                     ),
                                     dbc.Col(
@@ -111,7 +111,7 @@ def launch_app(_):
                                         className="p-0",
                                         style={"height": "80vh",
                                                "width": "70vw",
-                                               "overflow": "scroll"},
+                                               "overflow": "hidden"},
                                         width=10
                                     ),
                                 ]),
@@ -128,7 +128,7 @@ def launch_app(_):
                                         className="p-0",
                                         style={"height": "10vh",
                                                "width": "70vw",
-                                               "overflow": "hidden"},
+                                               "overflowX": "scroll"},
                                         width={"size": 10, "offset": 2}
                                     ),
                                 )],

--- a/app.py
+++ b/app.py
@@ -1025,31 +1025,21 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
         if not zoom_event and not autorange_event:
             raise PreventUpdate
 
-        first_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
-        first_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
-        previous_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
+        main_fig = go.Figure(old_main_fig)
+        main_fig_x_axis = go.Figure(old_main_fig_x_axis)
+        main_fig_y_axis = go.Figure(old_main_fig_y_axis)
 
+        old_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
         if zoom_event:
             new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
             new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
         else:
-            new_x_axis_range = first_x_axis_range
-            new_y_axis_range = first_y_axis_range
+            new_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
+            new_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
 
         # Should be about equal across x and y
-        change_in_range = new_x_axis_range[1]-new_x_axis_range[0]
-        overall_change_in_range = change_in_range
-        change_in_range /= \
-            (previous_x_axis_range[1]-previous_x_axis_range[0])
-        overall_change_in_range /= \
-            (first_x_axis_range[1]-first_x_axis_range[0])
-
-        if overall_change_in_range < 1 or overall_change_in_range > 5:
-            raise PreventUpdate
-
-        main_fig = go.Figure(old_main_fig)
-        main_fig_x_axis = go.Figure(old_main_fig_x_axis)
-        main_fig_y_axis = go.Figure(old_main_fig_y_axis)
+        change_in_range = new_x_axis_range[1] - new_x_axis_range[0]
+        change_in_range /= (old_x_axis_range[1] - old_x_axis_range[0])
 
         main_fig_nodes_trace = \
             [e for e in old_main_fig["data"]

--- a/app.py
+++ b/app.py
@@ -1018,7 +1018,11 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
                      "xaxis.range[1]",
                      "yaxis.range[0]",
                      "yaxis.range[1]"]
-        if not all([e in relayout_data for e in zoom_keys]):
+        autorange_keys = ["xaxis.autorange",
+                          "yaxis.autorange"]
+        zoom_event = all([e in relayout_data for e in zoom_keys])
+        autorange_event = all([e in relayout_data for e in autorange_keys])
+        if not zoom_event and not autorange_event:
             raise PreventUpdate
 
         main_fig = go.Figure(old_main_fig)
@@ -1026,8 +1030,13 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
         main_fig_y_axis = go.Figure(old_main_fig_y_axis)
 
         old_x_axis_range = old_main_fig_x_axis["layout"]["xaxis"]["range"]
-        new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
-        new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
+        if zoom_event:
+            new_x_axis_range = old_main_fig["layout"]["xaxis"]["range"]
+            new_y_axis_range = old_main_fig["layout"]["yaxis"]["range"]
+        else:
+            new_x_axis_range = old_main_fig_x_axis["data"][0]["customdata"]
+            new_y_axis_range = old_main_fig_y_axis["data"][0]["customdata"]
+
         # Should be about equal across x and y
         change_in_range = new_x_axis_range[1] - new_x_axis_range[0]
         change_in_range /= (old_x_axis_range[1] - old_x_axis_range[0])
@@ -1052,8 +1061,10 @@ def update_main_viz(selected_nodes, _, relayout_data, sample_file_contents,
                                           "name": "main_fig_y_axis_trace"
                                       })
 
-        main_fig.update_layout(xaxis={"range": new_x_axis_range},
-                               yaxis={"range": new_y_axis_range})
+        main_fig.update_layout(xaxis={"range": new_x_axis_range,
+                                      "autorange": False},
+                               yaxis={"range": new_y_axis_range,
+                                      "autorange": False})
         main_fig_x_axis.update_layout(xaxis={"range": new_x_axis_range})
         main_fig_y_axis.update_layout(yaxis={"range": new_y_axis_range})
 

--- a/assets/clientside-callbacks.js
+++ b/assets/clientside-callbacks.js
@@ -43,13 +43,20 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
           document.getElementById('main-graph-x-axis-col');
       const mainGraphYAxisColEl =
           document.getElementById('main-graph-y-axis-col');
-      mainGraphColEl.addEventListener(
+      mainGraphXAxisColEl.addEventListener(
           'scroll',
           ()=> {
-            const scrollLeft = mainGraphColEl.scrollLeft;
-            const scrollTop = mainGraphColEl.scrollTop;
-            mainGraphXAxisColEl.scroll(scrollLeft, 0);
-            mainGraphYAxisColEl.scroll(0, scrollTop);
+            const scrollLeft = mainGraphXAxisColEl.scrollLeft;
+            const scrollTop = mainGraphYAxisColEl.scrollTop;
+            mainGraphColEl.scroll(scrollLeft, scrollTop);
+          }
+      );
+      mainGraphYAxisColEl.addEventListener(
+          'scroll',
+          ()=> {
+            const scrollLeft = mainGraphXAxisColEl.scrollLeft;
+            const scrollTop = mainGraphYAxisColEl.scrollTop;
+            mainGraphColEl.scroll(scrollLeft, scrollTop);
           }
       );
       return true;

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -141,12 +141,10 @@ def get_main_fig(app_data):
             "showlegend": False,
             "xaxis": {
                 "range": app_data["main_fig_xaxis_range"],
-                # "fixedrange": True,
                 "visible": False
             },
             "yaxis": {
                 "range": app_data["main_fig_yaxis_range"],
-                # "fixedrange": True,
                 "visible": False
             },
             "plot_bgcolor": "white",
@@ -304,7 +302,8 @@ def get_main_fig_x_axis(app_data):
             textfont={
                 "size": 16
             },
-            hoverinfo="skip"
+            hoverinfo="skip",
+            name="main_fig_x_axis_trace"
         ),
         layout={
             "margin": {
@@ -345,7 +344,8 @@ def get_main_fig_y_axis(app_data):
             textfont={
                 "size": 16
             },
-            hoverinfo="skip"
+            hoverinfo="skip",
+            name="main_fig_y_axis_trace"
         ),
         layout={
             "margin": {

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -303,7 +303,8 @@ def get_main_fig_x_axis(app_data):
                 "size": 16
             },
             hoverinfo="skip",
-            name="main_fig_x_axis_trace"
+            name="main_fig_x_axis_trace",
+            customdata=app_data["main_fig_xaxis_range"]
         ),
         layout={
             "margin": {
@@ -345,7 +346,8 @@ def get_main_fig_y_axis(app_data):
                 "size": 16
             },
             hoverinfo="skip",
-            name="main_fig_y_axis_trace"
+            name="main_fig_y_axis_trace",
+            customdata=app_data["main_fig_yaxis_range"]
         ),
         layout={
             "margin": {

--- a/main_fig_generator.py
+++ b/main_fig_generator.py
@@ -31,7 +31,8 @@ def get_main_fig_nodes(app_data):
             "size": 16
         },
         hoverinfo="text",
-        hovertext=app_data["main_fig_nodes_hovertext"]
+        hovertext=app_data["main_fig_nodes_hovertext"],
+        name="main_fig_nodes_trace"
     )
     return nodes
 
@@ -140,15 +141,16 @@ def get_main_fig(app_data):
             "showlegend": False,
             "xaxis": {
                 "range": app_data["main_fig_xaxis_range"],
-                "fixedrange": True,
+                # "fixedrange": True,
                 "visible": False
             },
             "yaxis": {
                 "range": app_data["main_fig_yaxis_range"],
-                "fixedrange": True,
+                # "fixedrange": True,
                 "visible": False
             },
-            "plot_bgcolor": "white"
+            "plot_bgcolor": "white",
+            "dragmode": "pan"
         },
     )
 


### PR DESCRIPTION
Users can now scroll in the main plot to zoom in and out.

They can also drag the plot and move it around.

If you want to scroll through the plot, the scrollbars are now on the axes.