### PR TITLE
Pin werkzeug to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 dash==1.20.0
 dash-bootstrap-components==0.12.2
 networkx==2.8.5
+# https://github.com/plotly/dash/issues/1992
+Werkzeug==2.0.0


### PR DESCRIPTION
Due to bug in dash:

https://github.com/plotly/dash/issues/1992
