### PR TITLE
Simplify weight and label options

### DIFF
--- a/config_files/harris_data_config.json
+++ b/config_files/harris_data_config.json
@@ -17,6 +17,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     }

--- a/config_files/mulvey_data_config.json
+++ b/config_files/mulvey_data_config.json
@@ -18,6 +18,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 1,
       "weight_exp": "@SNV distance@-!SNV distance!",
+      "show_weights": 1,
       "weight_filters": {},
       "attr_filters": {}
     },
@@ -28,6 +29,7 @@
       "minimize_loops": 1,
       "show_arrowheads": 1,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {
       }

--- a/config_files/sample_data_config.json
+++ b/config_files/sample_data_config.json
@@ -17,6 +17,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     },
@@ -27,6 +28,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     },
@@ -37,6 +39,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     },
@@ -47,6 +50,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     },
@@ -57,6 +61,7 @@
       "minimize_loops": 0,
       "show_arrowheads": 0,
       "weight_exp": "",
+      "show_weights": 0,
       "weight_filters": {},
       "attr_filters": {}
     }

--- a/config_files/senterica_clusters_07282022_config.json
+++ b/config_files/senterica_clusters_07282022_config.json
@@ -17,6 +17,7 @@
       "minimize_loops": 1,
       "show_arrowheads": 0,
       "weight_exp": "abs(@snp_dist@-!snp_dist!)",
+      "show_weights": 1,
       "weight_filters": {
         "greater_than": 5
       },

--- a/data_parser.py
+++ b/data_parser.py
@@ -228,6 +228,7 @@ def get_app_data(sample_file_base64_str, config_file_base64_str,
 
     main_fig_link_labels_dict = get_main_fig_link_labels_dict(
         sample_links_dict=sample_links_dict,
+        links_config=config_file_dict["links_config"],
         main_fig_links_dict=main_fig_links_dict,
         main_fig_nodes_x_dict=main_fig_nodes_x_dict,
         selected_samples=selected_samples,
@@ -988,14 +989,17 @@ def get_main_fig_link_arrowheads_dict(main_fig_links_dict, links_config,
     return ret
 
 
-def get_main_fig_link_labels_dict(sample_links_dict, main_fig_links_dict,
-                                  main_fig_nodes_x_dict, selected_samples,
-                                  main_fig_height, main_fig_width, xaxis_range,
-                                  yaxis_range):
+def get_main_fig_link_labels_dict(sample_links_dict, links_config,
+                                  main_fig_links_dict, main_fig_nodes_x_dict,
+                                  selected_samples, main_fig_height,
+                                  main_fig_width, xaxis_range, yaxis_range):
     """Get dict with info used by Plotly to viz link labels.
 
     :param sample_links_dict: ``get_sample_links_dict`` ret val
     :type sample_links_dict: dict
+    :param links_config: dict of criteria for different user-specified
+        links.
+    :type links_config: dict
     :param main_fig_links_dict: Dict with info used by Plotly to viz
         links in main graph.
     :param main_fig_nodes_x_dict: ``get_main_fig_nodes_x_dict`` ret val
@@ -1020,6 +1024,8 @@ def get_main_fig_link_labels_dict(sample_links_dict, main_fig_links_dict,
     y_pixel_per_unit = main_fig_height / (yaxis_range[1] - yaxis_range[0])
 
     for link in sample_links_dict:
+        if not links_config[link]["show_weights"]:
+            continue
         ret[link] = {"x": [], "y": [], "text": [], "textangle": []}
 
         # Keeping a local variable instead of using ``enumerate``,


### PR DESCRIPTION
If the user supplies `weight_exp`, it will be used as link weights in Kruskal's.
If the user does not supply `weight_exp`, graphical distance b/w nodes will be used.

Users can choose whether to show weight labels with `show_weights`.