### PR TITLE
Improve upload workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -303,11 +303,13 @@ def toggle_upload_data_modal(_, __):
     Output("select-matrix-file-btn", "style"),
     Output("select-config-file-modal-header", "style"),
     Output("select-config-file-modal-body", "style"),
+    Output("upload-example-file", "contents"),
+    Output("upload-example-file", "filename"),
     Input("upload-sample-file", "contents"),
     Input("upload-sample-file", "filename"),
     prevent_initial_call=True
 )
-def edit_upload_data_modal_after_sample_file_upload(_, filename):
+def edit_upload_data_modal_after_sample_file_upload(contents, filename):
     """Edit upload data modal css after user uploads sample file.
 
     Current changes:
@@ -315,14 +317,16 @@ def edit_upload_data_modal_after_sample_file_upload(_, filename):
     * Filename replaces content of upload sample file btn
     * Upload sample file btn color changes
     * Hidden parts of modal become visible
+    * Example tabular file == uploaded file
 
-    :param _: User uploaded sample file
+    :param contents: User uploaded sample file contents
+    :type contents: contents
     :param filename: Sample filename
     :type filename: str
     :return: Text inside upload sample file btn, and btn color
     :rtype: (str, str, dict, dict, dict)
     """
-    return filename, "success", {}, {}, {}
+    return filename, "success", {}, {}, {}, contents, filename
 
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -305,6 +305,9 @@ def toggle_upload_data_modal(_, __):
 @app.callback(
     Output("select-sample-file-btn", "children"),
     Output("select-sample-file-btn", "color"),
+    Output("select-matrix-file-btn", "style"),
+    Output("select-config-file-modal-header", "style"),
+    Output("select-config-file-modal-body", "style"),
     Input("upload-sample-file", "contents"),
     Input("upload-sample-file", "filename"),
     prevent_initial_call=True
@@ -316,14 +319,15 @@ def edit_upload_data_modal_after_sample_file_upload(_, filename):
 
     * Filename replaces content of upload sample file btn
     * Upload sample file btn color changes
+    * Hidden parts of modal become visibile
 
     :param _: User uploaded sample file
     :param filename: Sample filename
     :type filename: str
     :return: Text inside upload sample file btn, and btn color
-    :rtype: (str, str)
+    :rtype: (str, str, dict, dict, dict)
     """
-    return filename, "success"
+    return filename, "success", {}, {}, {}
 
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -82,11 +82,6 @@ def launch_app(_):
                 width="auto"
                 ),
                 dbc.Col(
-                    dbc.Button("Create config file",
-                               id="create-config-file-btn"),
-                    width="auto"
-                ),
-                dbc.Col(
                     dcc.Loading(
                         html.Div(id="graph-loading"),
                         type="circle"

--- a/app.py
+++ b/app.py
@@ -74,7 +74,8 @@ def launch_app(_):
         dbc.Row(
             children=[
                 dbc.Col(
-                    dbc.Button("Upload data",
+                    dbc.Button(html.I(className="bi-upload",
+                                      style={"font-size": 16}),
                                id="upload-data-btn",
                                className="mr-1",
                                color="primary"),

--- a/app.py
+++ b/app.py
@@ -314,7 +314,7 @@ def edit_upload_data_modal_after_sample_file_upload(_, filename):
 
     * Filename replaces content of upload sample file btn
     * Upload sample file btn color changes
-    * Hidden parts of modal become visibile
+    * Hidden parts of modal become visible
 
     :param _: User uploaded sample file
     :param filename: Sample filename

--- a/app.py
+++ b/app.py
@@ -500,14 +500,16 @@ def add_create_config_modal_form(example_file_contents, delimiter):
 
 
 @app.callback(
-    Output({"type": "form-help-alert", "index": MATCH},"is_open"),
-    Input({"type": "form-help-btn", "index": MATCH},"n_clicks"),
-    State({"type": "form-help-alert", "index": MATCH},
+    Output({"type": "create-config-modal-help-alert", "index": MATCH},
+           "is_open"),
+    Input({"type": "create-config-modal-help-btn", "index": MATCH},
+          "n_clicks"),
+    State({"type": "create-config-modal-help-alert", "index": MATCH},
           "is_open"),
     prevent_initial_call=True
 )
-def toggle_form_help_alert(_, is_already_open):
-    """Toggle a help alert in upload and create config modal.
+def toggle_create_config_modal_help_alert(_, is_already_open):
+    """Toggle a help alert in create config modal.
 
     :param _: User clicked help btn for an alert
     :param is_already_open: Is the alert already open?

--- a/app.py
+++ b/app.py
@@ -500,16 +500,14 @@ def add_create_config_modal_form(example_file_contents, delimiter):
 
 
 @app.callback(
-    Output({"type": "create-config-modal-help-alert", "index": MATCH},
-           "is_open"),
-    Input({"type": "create-config-modal-help-btn", "index": MATCH},
-          "n_clicks"),
-    State({"type": "create-config-modal-help-alert", "index": MATCH},
+    Output({"type": "form-help-alert", "index": MATCH},"is_open"),
+    Input({"type": "form-help-btn", "index": MATCH},"n_clicks"),
+    State({"type": "form-help-alert", "index": MATCH},
           "is_open"),
     prevent_initial_call=True
 )
-def toggle_create_config_modal_help_alert(_, is_already_open):
-    """Toggle a help alert in create config modal.
+def toggle_form_help_alert(_, is_already_open):
+    """Toggle a help alert in upload and create config modal.
 
     :param _: User clicked help btn for an alert
     :param is_already_open: Is the alert already open?

--- a/app.py
+++ b/app.py
@@ -76,18 +76,11 @@ def launch_app(_):
         dbc.Row(
             children=[
                 dbc.Col(
-                    [
-                        dbc.Button(html.I(className="bi-upload",
-                                          style={"font-size": 16}),
-                                   id="upload-data-btn",
-                                   className="mr-1",
-                                   color="primary"),
-                        dbc.Tooltip(
-                            "Upload data",
-                            target="upload-data-btn"
-                        )
-                    ],
-                width="auto"
+                    dbc.Button("Upload data",
+                               id="upload-data-btn",
+                               className="mr-1",
+                               color="primary"),
+                    width="auto"
                 ),
                 dbc.Col(
                     dcc.Loading(

--- a/app.py
+++ b/app.py
@@ -696,6 +696,7 @@ def start_config_file_generation(_, __, dl_btn_color, ret_btn_color):
 @app.callback(
     Output("config-error-msg-label", "children"),
     Output("config-error-msg-col", "style"),
+    Output("sample-field-select", "invalid"),
     Output("date-field-select", "invalid"),
     Output("date-input-format-input", "invalid"),
     Output("date-output-format-input", "invalid"),
@@ -704,6 +705,7 @@ def start_config_file_generation(_, __, dl_btn_color, ret_btn_color):
     Output("config-json-str", "data"),
     Input("config-file-generation-started", "data"),
     State("delimiter-select", "value"),
+    State("sample-field-select", "value"),
     State("date-field-select", "value"),
     State("date-input-format-input", "value"),
     State("date-output-format-input", "value"),
@@ -723,6 +725,8 @@ def start_config_file_generation(_, __, dl_btn_color, ret_btn_color):
     State({"type": "link-minimize-loops", "index": ALL}, "checked"),
     State({"type": "link-arrowheads", "index": ALL}, "id"),
     State({"type": "link-arrowheads", "index": ALL}, "checked"),
+    State({"type": "show-link-weights", "index": ALL}, "id"),
+    State({"type": "show-link-weights", "index": ALL}, "checked"),
     State({"type": "link-weight-exp", "index": ALL}, "id"),
     State({"type": "link-weight-exp", "index": ALL}, "value"),
     State({"type": "link-weight-lt", "index": ALL}, "id"),
@@ -742,7 +746,7 @@ def start_config_file_generation(_, __, dl_btn_color, ret_btn_color):
     State({"type": "link-any-eq-select", "index": ALL}, "value"),
     prevent_initial_call=True
 )
-def continue_config_file_generation(started, delimiter,
+def continue_config_file_generation(started, delimiter, sample_field,
                                     date_field, date_input_format,
                                     date_output_format, links_across_primary_y,
                                     max_day_range, empty_strings_are_null,
@@ -753,6 +757,7 @@ def continue_config_file_generation(started, delimiter,
                                     link_label_ids, link_label_vals,
                                     link_min_loop_ids, link_min_loop_vals,
                                     link_arrowhead_ids, link_arrowhead_vals,
+                                    show_link_weights_ids, show_link_weights_vals,
                                     link_weight_exp_ids, link_weight_exp_vals,
                                     link_weight_lt_ids, link_weight_lt_vals,
                                     link_weight_gt_ids, link_weight_gt_vals,
@@ -772,6 +777,8 @@ def continue_config_file_generation(started, delimiter,
     :type started: bool
     :param delimiter: User-specified example file delimiter
     :type delimiter: str
+    :param sample_field: User-specified sample ID field
+    :type sample_field: str
     :param date_field: User-specified date field
     :type date_field: str
     :param date_input_format: User-specified date input format
@@ -811,6 +818,10 @@ def continue_config_file_generation(started, delimiter,
     :type link_arrowhead_ids: list[dict]
     :param link_arrowhead_vals: Vals of link arrowhead checkboxes
     :type link_arrowhead_vals: list[bool]
+    :param show_link_weights_ids: IDs of show link weights checkboxes
+    :type show_link_weights_ids: list[dict]
+    :param show_link_weights_vals: Vals of show link weights checkboxes
+    :type show_link_weights_vals: list[bool]
     :param link_weight_exp_ids: IDs of link weight exp inputs
     :type link_weight_exp_ids: list[dict]
     :param link_weight_exp_vals: Vals of link weight exp inputs
@@ -855,7 +866,8 @@ def continue_config_file_generation(started, delimiter,
     if not started:
         raise PreventUpdate
 
-    mandatory_non_link_fields = [date_field,
+    mandatory_non_link_fields = [sample_field,
+                                 date_field,
                                  date_input_format,
                                  date_output_format,
                                  first_y_axis_field]
@@ -901,6 +913,8 @@ def continue_config_file_generation(started, delimiter,
         link_dict[id_["index"]]["minimize_loops"] = int(val)
     for id_, val in zip(link_arrowhead_ids, link_arrowhead_vals):
         link_dict[id_["index"]]["show_arrowheads"] = int(val)
+    for id_, val in zip(show_link_weights_ids, show_link_weights_vals):
+        link_dict[id_["index"]]["show_weights"] = int(val)
     for id_, val in zip(link_weight_exp_ids, link_weight_exp_vals):
         if val is None:
             val = ""
@@ -969,6 +983,7 @@ def continue_config_file_generation(started, delimiter,
                ""
 
     config_dict = {
+        "sample_id": sample_field,
         "delimiter": delimiter,
         "date_attr": date_field,
         "date_input": date_input_format,
@@ -976,7 +991,7 @@ def continue_config_file_generation(started, delimiter,
         "links_across_primary_y": int(links_across_primary_y),
         "max_day_range": max_day_range,
         "null_vals": null_vals,
-        "primary_y_axis": first_y_axis_field,
+        "primary_y_axis": [first_y_axis_field],
         "secondary_y_axes": [[e] for e in y_axis_fields[1:]
                              if e is not None or ""],
         "label_attr": [e for e in node_label_fields

--- a/app.py
+++ b/app.py
@@ -404,14 +404,16 @@ def toggle_viz_btn_color(sample_file_contents, config_file_contents):
 @app.callback(
     Output("create-config-file-modal", "is_open"),
     Input("create-config-file-btn", "n_clicks"),
+    Input("create-config-file-link", "n_clicks"),
     Input("upload-config-file", "contents"),
     prevent_intial_call=True
 )
-def toggle_create_config_file_modal(_, __):
+def toggle_create_config_file_modal(_, __, ___):
     """Toggle create config modal.
 
     :param _: Create config file btn clicked
-    :param __: Config file uploaded
+    :param _: Create config file link clicked
+    :param ___: Config file uploaded
     :return: Whether modal is open or closed
     :rtype: bool
     :raise RuntimeError: Unexpected trigger trying to toggle modal
@@ -421,6 +423,8 @@ def toggle_create_config_file_modal(_, __):
     if trigger == ".":
         raise PreventUpdate
     elif trigger == "create-config-file-btn.n_clicks":
+        return True
+    elif trigger == "create-config-file-link.n_clicks":
         return True
     # This closes the modal if user generates config file via ret btn
     elif trigger == "upload-config-file.contents":

--- a/app.py
+++ b/app.py
@@ -302,7 +302,7 @@ def toggle_upload_data_modal(_, __):
 @app.callback(
     Output("select-sample-file-btn", "children"),
     Output("select-sample-file-btn", "color"),
-    Output("select-matrix-file-btn", "style"),
+    Output("select-matrix-file-row", "style"),
     Output("select-config-file-modal-header", "style"),
     Output("select-config-file-modal-body", "style"),
     Output("upload-example-file", "contents"),

--- a/app.py
+++ b/app.py
@@ -76,11 +76,17 @@ def launch_app(_):
         dbc.Row(
             children=[
                 dbc.Col(
-                    dbc.Button(html.I(className="bi-upload",
-                                      style={"font-size": 16}),
-                               id="upload-data-btn",
-                               className="mr-1",
-                               color="primary"),
+                    [
+                        dbc.Button(html.I(className="bi-upload",
+                                          style={"font-size": 16}),
+                                   id="upload-data-btn",
+                                   className="mr-1",
+                                   color="primary"),
+                        dbc.Tooltip(
+                            "Upload data",
+                            target="upload-data-btn"
+                        )
+                    ],
                 width="auto"
                 ),
                 dbc.Col(

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from base64 import b64encode
 from json import dumps
 from pathlib import Path
 from sys import maxsize
+from traceback import format_exc
 
 import dash
 from dash import Dash
@@ -1375,7 +1376,9 @@ def update_link_legend_neq_dict(link_legend_filter_ids,
         Output("node-color-legend-graph", "figure"),
         Output("y-axis-legend-col", "children"),
         Output("graph-loading", "children"),
-        Output("stale-vals-tbl", "data")
+        Output("stale-vals-tbl", "data"),
+        Output("upload-error-msg", "children"),
+        Output("upload-error-msg", "className")
     ],
     prevent_initial_call=True
 )
@@ -1398,6 +1401,8 @@ def update_main_viz(selected_nodes, filtered_node_symbols,
     * User modifies link slider vals
     * User modifies link filter forms
     * User adjusts zoom level of free-zoom graph
+
+    Also displays error messages on failed upload.
 
     :param selected_nodes: Currently selected nodes
     :type selected_nodes: dict
@@ -1556,27 +1561,42 @@ def update_main_viz(selected_nodes, filtered_node_symbols,
             if "filtered-link-types" in stale_vals_tbl:
                 filtered_link_types = {}
 
-        app_data = \
-            get_app_data(sample_file_base64_str,
-                         config_file_base64_str,
-                         matrix_file_base64_str=matrix_file_base64_str,
-                         selected_nodes=selected_nodes,
-                         filtered_node_symbols=filtered_node_symbols,
-                         filtered_node_colors=filtered_node_colors,
-                         filtered_link_types=filtered_link_types,
-                         link_slider_vals_dict=link_legend_slider_vals_dict,
-                         link_neq_dict=link_legend_neq_dict)
-        zoomed_out_app_data = \
-            get_app_data(sample_file_base64_str,
-                         config_file_base64_str,
-                         matrix_file_base64_str=matrix_file_base64_str,
-                         selected_nodes=selected_nodes,
-                         filtered_node_symbols=filtered_node_symbols,
-                         filtered_node_colors=filtered_node_colors,
-                         filtered_link_types=filtered_link_types,
-                         link_slider_vals_dict=link_legend_slider_vals_dict,
-                         link_neq_dict=link_legend_neq_dict,
-                         vpsc=True)
+        try:
+            app_data = \
+                get_app_data(
+                    sample_file_base64_str,
+                    config_file_base64_str,
+                    matrix_file_base64_str=matrix_file_base64_str,
+                    selected_nodes=selected_nodes,
+                    filtered_node_symbols=filtered_node_symbols,
+                    filtered_node_colors=filtered_node_colors,
+                    filtered_link_types=filtered_link_types,
+                    link_slider_vals_dict=link_legend_slider_vals_dict,
+                    link_neq_dict=link_legend_neq_dict
+                )
+            zoomed_out_app_data = \
+                get_app_data(
+                    sample_file_base64_str,
+                    config_file_base64_str,
+                    matrix_file_base64_str=matrix_file_base64_str,
+                    selected_nodes=selected_nodes,
+                    filtered_node_symbols=filtered_node_symbols,
+                    filtered_node_colors=filtered_node_colors,
+                    filtered_link_types=filtered_link_types,
+                    link_slider_vals_dict=link_legend_slider_vals_dict,
+                    link_neq_dict=link_legend_neq_dict,
+                    vpsc=True
+                )
+        except Exception:
+            error_msg = [
+                html.B("Ran into an unvalidated error while parsing the data files!"),
+                html.Br(),
+                format_exc()
+            ]
+            # TODO really hackey; solution is to maybe have a return
+            #  dict. Then we know # of return vals.
+            return [no_update]*15 + [error_msg, "pt-0 text-danger"]
+
         main_fig = get_main_fig(app_data)
         zoomed_out_main_fig = get_zoomed_out_main_fig(zoomed_out_app_data)
         node_symbol_legend_fig = get_node_symbol_legend_fig(app_data)
@@ -1643,7 +1663,9 @@ def update_main_viz(selected_nodes, filtered_node_symbols,
             node_color_legend_fig,
             y_axis_legend,
             graph_loading,
-            stale_vals_tbl)
+            stale_vals_tbl,
+            "",
+            "d-none pt-0 text-danger")
 
 
 # Switch to main graph tab and scroll to corresponding node, after

--- a/app.py
+++ b/app.py
@@ -249,13 +249,14 @@ def launch_app(_):
         dcc.Store("new-upload", data=False),
         dcc.Store("stale-vals-tbl", data={}),
         dcc.Store("example-file-field-opts"),
-        dcc.Store("config-file-generation-started", data=False),
         dcc.Store("config-json-str", data=""),
         dcc.Download(id="download-config-json-str"),
         # These dicts are easier to work with then the dcc vals
         dcc.Store(id="link-legend-slider-vals-dict", data={}),
         dcc.Store(id="link-legend-filter-collapse-states-dict", data={}),
-        dcc.Store(id="link-legend-neq-dict", data={})
+        dcc.Store(id="link-legend-neq-dict", data={}),
+        # Will be either "download" or "return" going forward
+        dcc.Store("config-file-generation-started", data=False)
     ]
 
     return children
@@ -646,27 +647,46 @@ def contract_create_config_modal_form(_):
 @app.callback(
     Output("config-file-generation-started", "data"),
     Input("download-config-file-btn", "n_clicks"),
+    Input("return-config-file-btn", "n_clicks"),
     State("download-config-file-btn", "color"),
+    State("return-config-file-btn", "color"),
     prevent_initial_call=True
 )
-def start_config_file_generation(_, btn_color):
+def start_config_file_generation(_, __, dl_btn_color, ret_btn_color):
     """Start generating the config file.
 
     We populate the config file generation started browser var, which
-    starts the next phase. We do not proceed if the btn is not the
+    starts the next phase. We do not proceed if the btns are not the
     right color yet.
 
     :param _: User clicked btn for downloading config file
-    :param btn_color: Color of btn for downloading config file when
+    :param __: User clicked btn for returning config file
+    :param dl_btn_color: Color of btn for downloading config file when
         user clicked it.
-    :type btn_color: str
-    :return: Config file generation started browser var
-    :rtype: bool
+    :type dl_btn_color: str
+    :param ret_btn_color: Color of btn for returning config file when
+        user clicked it.
+    :type ret_btn_color: str
+    :return: Config file generation started browser var; one of
+        `"download"` or `"return"`.
+    :rtype: str
     """
-    if btn_color != "info":
-        raise PreventUpdate
+    ctx = dash.callback_context
+    trigger = ctx.triggered[0]["prop_id"]
 
-    return True
+    if trigger == "download-config-file-btn.n_clicks":
+        if dl_btn_color != "info":
+            raise PreventUpdate
+        else:
+            return "download"
+    elif trigger == "return-config-file-btn.n_clicks":
+        if ret_btn_color != "primary":
+            raise PreventUpdate
+        else:
+            return "return"
+    else:
+        msg = "Unexpected trigger %s when starting config file generation"
+        raise(ValueError(msg % trigger))
 
 
 @app.callback(
@@ -975,14 +995,24 @@ def continue_config_file_generation(started, delimiter,
 @app.callback(
     Output("download-config-json-str", "data"),
     Input("config-json-str", "data"),
+    State("config-file-generation-started", "data"),
     State("upload-example-file", "filename"),
     prevent_initial_call=True
 )
-def download_config_file(config_json_str, filename):
-    """Launch download of generated config file.
+def process_generated_config_file(config_json_str, dl_or_ret, filename):
+    """Process generated config file.
+
+    Depending on which btn in the create config modal the user clicked,
+    this could be either downloading the file, or returning to the
+    upload data modal with the new config data acting as an "uploaded
+    file".
 
     :param config_json_str: In-browser config json str var
     :type config_json_str: str
+    :param dl_or_ret: Specifies whether process of config file
+        generation began by user clicking dl or ret btn; should be
+        either "download" or "return".
+    :type dl_or_ret: str
     :param filename: Uploaded example file filename
     :type filename: str
     :return: New contents for in-browser var that triggers download
@@ -991,7 +1021,11 @@ def download_config_file(config_json_str, filename):
     if config_json_str == "":
         raise PreventUpdate
     json_filename = Path(filename).stem + ".json"
-    return {"content": config_json_str, "filename": json_filename}
+    if dl_or_ret == "download":
+        return {"content": config_json_str, "filename": json_filename}
+    else:
+        msg = "Unexpected value %s when processing generated config file"
+        raise(ValueError(msg % dl_or_ret))
 
 
 @app.callback(

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 Running this script launches the application.
 """
 
+from base64 import b64encode
 from json import dumps
 from pathlib import Path
 from sys import maxsize
@@ -994,6 +995,8 @@ def continue_config_file_generation(started, delimiter,
 
 @app.callback(
     Output("download-config-json-str", "data"),
+    Output("upload-config-file", "filename"),
+    Output("upload-config-file", "contents"),
     Input("config-json-str", "data"),
     State("config-file-generation-started", "data"),
     State("upload-example-file", "filename"),
@@ -1015,14 +1018,24 @@ def process_generated_config_file(config_json_str, dl_or_ret, filename):
     :type dl_or_ret: str
     :param filename: Uploaded example file filename
     :type filename: str
-    :return: New contents for in-browser var that triggers download
-    :rtype: dict
+    :return: New contents for in-browser var that triggers download, or
+        uploaded config file.
+    :rtype: tuple[dict | dash.dash.no_update | str]
     """
     if config_json_str == "":
         raise PreventUpdate
     json_filename = Path(filename).stem + ".json"
     if dl_or_ret == "download":
-        return {"content": config_json_str, "filename": json_filename}
+        return ({"content": config_json_str, "filename": json_filename},
+                no_update,
+                no_update)
+    elif dl_or_ret == "return":
+        # Hackey, but necessary, given the format Dash expects uploaded
+        # files.
+        contents = ",%s" % str(b64encode(config_json_str.encode("utf-8")))[2:]
+        return (no_update,
+                json_filename,
+                contents)
     else:
         msg = "Unexpected value %s when processing generated config file"
         raise(ValueError(msg % dl_or_ret))

--- a/app.py
+++ b/app.py
@@ -452,7 +452,8 @@ def edit_create_config_modal_after_example_file_upload(_, filename):
 
 @app.callback(
     Output("create-config-file-modal-form", "children"),
-    Output("generate-config-file-btn", "color"),
+    Output("download-config-file-btn", "color"),
+    Output("return-config-file-btn", "color"),
     Output("example-file-field-opts", "data"),
     Input("upload-example-file", "contents"),
     Input("delimiter-select", "value"),
@@ -465,7 +466,7 @@ def add_create_config_modal_form(example_file_contents, delimiter):
     delimiter, but we only want to add the form if both actions have
     been completed.
 
-    We also change the color of the btn at the bottom of the create
+    We also change the color of the btns at the bottom of the create
     config modal for actually generating the file, and we store the
     example file field select opts in a browser var.
 
@@ -473,8 +474,8 @@ def add_create_config_modal_form(example_file_contents, delimiter):
     :type example_file_contents: str
     :param delimiter: User-specified example file delimiter
     :type delimiter: str
-    :return: Create config modal form, color of btn for actually
-        generating config file, and example file fields select opts
+    :return: Create config modal form, color of btns for downloading or
+        returning config file, and example file fields select opts
         browser var.
     :rtype: (list[dbc.Row], str, list)
     """
@@ -490,7 +491,7 @@ def add_create_config_modal_form(example_file_contents, delimiter):
 
     form = get_create_config_modal_form(example_file_field_opts)
 
-    return form, "primary", example_file_field_opts
+    return form, "info", "primary", example_file_field_opts
 
 
 @app.callback(
@@ -644,8 +645,8 @@ def contract_create_config_modal_form(_):
 
 @app.callback(
     Output("config-file-generation-started", "data"),
-    Input("generate-config-file-btn", "n_clicks"),
-    State("generate-config-file-btn", "color"),
+    Input("download-config-file-btn", "n_clicks"),
+    State("download-config-file-btn", "color"),
     prevent_initial_call=True
 )
 def start_config_file_generation(_, btn_color):
@@ -655,14 +656,14 @@ def start_config_file_generation(_, btn_color):
     starts the next phase. We do not proceed if the btn is not the
     right color yet.
 
-    :param _: User clicked btn for generating config file
-    :param btn_color: Color of btn for generating config file when user
-        clicked it.
+    :param _: User clicked btn for downloading config file
+    :param btn_color: Color of btn for downloading config file when
+        user clicked it.
     :type btn_color: str
     :return: Config file generation started browser var
     :rtype: bool
     """
-    if btn_color != "primary":
+    if btn_color != "info":
         raise PreventUpdate
 
     return True

--- a/app.py
+++ b/app.py
@@ -322,13 +322,46 @@ def edit_upload_data_modal_after_sample_file_upload(contents, filename):
     * Example tabular file == uploaded file
 
     :param contents: User uploaded sample file contents
-    :type contents: contents
+    :type contents: str
     :param filename: Sample filename
     :type filename: str
     :return: Text inside upload sample file btn, and btn color
     :rtype: (str, str, dict, dict, dict)
     """
     return filename, "success", {}, {}, {}, contents, filename
+
+
+@app.callback(
+    Output("del-matrix-file-btn", "style"),
+    Input("upload-matrix-file", "contents"),
+    prevent_initial_call=True
+)
+def toggle_del_matrix_file_btn_visibility(contents):
+    """Toggle visibility of btn used to clear uploaded matrix file.
+
+    :param contents: User uploaded matrix file contents
+    :type contents: str
+    :return: Css dict dictating whether clear matrix btn is visible
+    :rtype: dict
+    """
+    if contents is None:
+        return {"display": "none"}
+    return {}
+
+
+@app.callback(
+    Output("upload-matrix-file", "contents"),
+    Input("del-matrix-file-btn", "n_clicks"),
+    prevent_initial_call=True
+)
+def clear_matrix_file(_):
+    """Clear uploaded matrix file when user clicks clear btn.
+
+    :param _: User clicked clear btn beside upload matrix file btn
+    :return: New, empty matrix file contents
+    :rtype: None
+    """
+    return None
 
 
 @app.callback(
@@ -362,20 +395,23 @@ def edit_upload_data_modal_after_config_file_upload(_, filename):
     Input("upload-matrix-file", "filename"),
     prevent_initial_call=True
 )
-def edit_upload_data_modal_after_matrix_file_upload(_, filename):
-    """Edit upload data modal css after user uploads matrix file.
+def edit_upload_data_modal_after_matrix_file_upload(contents, filename):
+    """Edit upload data modal css after upload/clear matrix file.
 
     Current changes:
 
     * Filename replaces content of upload matrix file btn
     * Upload matrix file btn color changes
 
-    :param _: User uploaded matrix file
+    :param contents: User uploaded matrix file contents
+    :type contents: str
     :param filename: Matrix filename
     :type filename: str
     :return: Text inside upload matrix file btn, and btn color
     :rtype: (str, str)
     """
+    if contents is None:
+        return "Optional matrix file", "light"
     return filename, "success"
 
 

--- a/app.py
+++ b/app.py
@@ -403,15 +403,15 @@ def toggle_viz_btn_color(sample_file_contents, config_file_contents):
 
 @app.callback(
     Output("create-config-file-modal", "is_open"),
-    inputs=[
-        Input("create-config-file-btn", "n_clicks")
-    ],
+    Input("create-config-file-btn", "n_clicks"),
+    Input("upload-config-file", "contents"),
     prevent_intial_call=True
 )
-def toggle_create_config_file_modal(_):
+def toggle_create_config_file_modal(_, __):
     """Toggle create config modal.
 
     :param _: Create config file btn clicked
+    :param __: Config file uploaded
     :return: Whether modal is open or closed
     :rtype: bool
     :raise RuntimeError: Unexpected trigger trying to toggle modal
@@ -422,6 +422,9 @@ def toggle_create_config_file_modal(_):
         raise PreventUpdate
     elif trigger == "create-config-file-btn.n_clicks":
         return True
+    # This closes the modal if user generates config file via ret btn
+    elif trigger == "upload-config-file.contents":
+        return False
     else:
         msg = "Unexpected trigger trying to " \
               "toggle create config file modal: %s" % trigger

--- a/app.py
+++ b/app.py
@@ -521,6 +521,24 @@ def toggle_create_config_modal_help_alert(_, is_already_open):
 
 
 @app.callback(
+    Output({"type": "upload-modal-help-alert", "index": MATCH},"is_open"),
+    Input({"type": "upload-modal-help-btn", "index": MATCH},"n_clicks"),
+    State({"type": "upload-modal-help-alert", "index": MATCH},"is_open"),
+    prevent_initial_call=True
+)
+def toggle_upload_modal_help_alert(_, is_already_open):
+    """Toggle a help alert in upload modal.
+
+    :param _: User clicked help btn for an alert
+    :param is_already_open: Is the alert already open?
+    :type is_already_open: bool
+    :return: Open status for alert specific to help btn user clicked
+    :rtype: bool
+    """
+    return not is_already_open
+
+
+@app.callback(
     Output({"type": "expandable-create-config-form-col", "index": MATCH},
            "children"),
     Input({"type": "expandable-create-config-form-btn", "index": MATCH},

--- a/data_parser.py
+++ b/data_parser.py
@@ -868,6 +868,7 @@ def filter_link_loops(sample_links_dict, links_config, main_fig_nodes_x_dict,
         prevent loops.
     :rtype: dict
     """
+    no_weights = set()
     for link in sample_links_dict:
         graph = nx.Graph()
         if not bool(links_config[link]["minimize_loops"]):
@@ -884,6 +885,7 @@ def filter_link_loops(sample_links_dict, links_config, main_fig_nodes_x_dict,
                 weight_info = {"weight": sqrt((x1-x0)**2 + (y1-y0)**2),
                                "filtered_by_neq": False,
                                "filtered_by_range": False}
+                no_weights.add((sample, other_sample))
 
             # Need to track original order because graph is undirected
             order = (sample, other_sample)
@@ -903,7 +905,15 @@ def filter_link_loops(sample_links_dict, links_config, main_fig_nodes_x_dict,
         new_link_dict = {}
         for edgeview in disjoint_mst_subgraph_edgeviews:
             for (sample, other_sample, data) in edgeview:
-                new_link_dict[data["order"]] = data["weight"]
+                if (sample, other_sample) in no_weights:
+                    weight = None
+                elif (other_sample, sample) in no_weights:
+                    weight = None
+                else:
+                    weight = data["weight"]
+                new_link_dict[data["order"]] = {"weight": weight,
+                                                "filtered_by_neq": False,
+                                                "filtered_by_range": False}
         sample_links_dict[link] = new_link_dict
 
     return sample_links_dict
@@ -1372,7 +1382,7 @@ def get_main_fig_link_labels_dict(sample_links_dict, links_config,
                 continue
 
             weight_info = sample_links_dict[link][(sample, other_sample)]
-            if any([weight_info is None,
+            if any([weight_info["weight"] is None,
                     weight_info["filtered_by_neq"],
                     weight_info["filtered_by_range"]]):
                 i += 1
@@ -1450,7 +1460,7 @@ def get_main_fig_arc_labels_dict(sample_links_dict, links_config,
                 continue
 
             weight_info = sample_links_dict[link][(sample, other_sample)]
-            if any([weight_info is None,
+            if any([weight_info["weight"] is None,
                     weight_info["filtered_by_neq"],
                     weight_info["filtered_by_range"]]):
                 i += 1

--- a/legend_fig_generator.py
+++ b/legend_fig_generator.py
@@ -77,7 +77,7 @@ def get_node_symbol_legend_fig(app_data):
             },
             "showlegend": False,
             "plot_bgcolor": "white",
-            "height": len(graph[0]["y"]) * 50
+            "height": max(10, len(graph[0]["y"]) * 50)
         },
     )
     return fig
@@ -359,5 +359,5 @@ def get_node_color_legend_fig(app_data):
         },
     )
     if graph:
-        fig.update_layout(height=len(graph[0]["y"] * 50))
+        fig.update_layout(height=max(10, len(graph[0]["y"] * 50)))
     return fig

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -76,7 +76,7 @@ def get_create_config_file_modal():
                         [
                             dbc.Col(
                                 dcc.Upload(
-                                    dbc.Button("Upload sample/example data "
+                                    dbc.Button("Upload sample/example tabular "
                                                "file",
                                                id="select-example-file-btn"),
                                     id="upload-example-file"

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -15,18 +15,12 @@ def get_upload_data_modal():
     """
     ret = dbc.Modal(
         [
-            dbc.ModalHeader("Upload data"),
+            dbc.ModalHeader("Upload tabular data"),
             dbc.ModalBody([
                 dcc.Upload(
-                    dbc.Button("Select sample data file",
+                    dbc.Button("Select tabular data file",
                                id="select-sample-file-btn"),
                     id="upload-sample-file"
-                ),
-                dcc.Upload(
-                    dbc.Button("Select config file",
-                               id="select-config-file-btn"),
-                    id="upload-config-file",
-                    className="mt-1"
                 ),
                 dcc.Upload(
                     dbc.Button("Optional matrix file",
@@ -36,6 +30,14 @@ def get_upload_data_modal():
                     className="mt-1"
                 )
             ]),
+            dbc.ModalHeader("Upload config file"),
+            dbc.ModalBody(
+                dcc.Upload(
+                    dbc.Button("Select config file",
+                               id="select-config-file-btn"),
+                    id="upload-config-file"
+                )
+            ),
             dbc.ModalFooter(
                 dbc.Button("Visualize", id="viz-btn")
             )

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -25,18 +25,23 @@ def get_upload_data_modal():
                 dcc.Upload(
                     dbc.Button("Optional matrix file",
                                id="select-matrix-file-btn",
-                               color="light"),
+                               color="light",
+                               style={"display": "none"}),
                     id="upload-matrix-file",
-                    className="mt-1"
+                    className="mt-2"
                 )
             ]),
-            dbc.ModalHeader("Upload config file"),
+            dbc.ModalHeader("Upload config file",
+                            id="select-config-file-modal-header",
+                            style={"display": "none"}),
             dbc.ModalBody(
                 dcc.Upload(
                     dbc.Button("Select config file",
                                id="select-config-file-btn"),
                     id="upload-config-file"
-                )
+                ),
+                id="select-config-file-modal-body",
+                style={"display": "none"}
             ),
             dbc.ModalFooter(
                 dbc.Button("Visualize", id="viz-btn")

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -35,11 +35,18 @@ def get_upload_data_modal():
                             id="select-config-file-modal-header",
                             style={"display": "none"}),
             dbc.ModalBody(
-                dcc.Upload(
-                    dbc.Button("Select config file",
-                               id="select-config-file-btn"),
-                    id="upload-config-file"
-                ),
+                [
+                    dcc.Upload(
+                        dbc.Button("Select config file",
+                                   id="select-config-file-btn"),
+                        id="upload-config-file"
+                    ),
+                    dbc.Button(
+                        "...or click here to create one from scratch",
+                        id="create-config-file-btn",
+                        color="link"
+                    )
+                ],
                 id="select-config-file-modal-body",
                 style={"display": "none"}
             ),

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -70,14 +70,15 @@ def get_upload_data_modal():
                         ),
                         dbc.Col(
                             dbc.Row([
-                                get_upload_help_btn("select-matrix-file"),
                                 dbc.Col(
-                                    dbc.Button("Delete",
-                                               id="select-matrix-file-btn-del",
+                                    dbc.Button("Clear",
+                                               id="del-matrix-file-btn",
                                                color="danger",
                                                size="sm",
-                                               className="p-0")
-                                )
+                                               className="p-0",
+                                               style={"display": "none"})
+                                ),
+                                get_upload_help_btn("select-matrix-file")
                             ]),
                             width="auto"
                         )

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -244,8 +244,8 @@ def get_create_config_modal_form(example_file_field_opts):
     :rtype: list
     """
     ret = [
-        get_create_config_help_btn("sample-id-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("sample-id-fields"),
+        get_form_help_alert(
             "sample-id-fields",
             [
                 P([
@@ -271,8 +271,8 @@ def get_create_config_modal_form(example_file_field_opts):
             ),
             className="mb-3"
         ),
-        get_create_config_help_btn("date-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("date-fields"),
+        get_form_help_alert(
             "date-fields",
             [
                 P([
@@ -332,8 +332,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("link-across-primary-y-field"),
-        get_create_config_help_alert(
+        get_form_help_btn("link-across-primary-y-field"),
+        get_form_help_alert(
             "link-across-primary-y-field",
             [
                 P([
@@ -365,8 +365,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("max-day-range-field"),
-        get_create_config_help_alert(
+        get_form_help_btn("max-day-range-field"),
+        get_form_help_alert(
             "max-day-range-field",
             [P("Links will not be drawn between nodes that were sampled more "
                "than this many days apart.")]
@@ -388,8 +388,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("null-val-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("null-val-fields"),
+        get_form_help_alert(
             "null-val-fields",
             [
                 P([
@@ -448,8 +448,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("y-axis-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("y-axis-fields"),
+        get_form_help_alert(
             "y-axis-fields",
             [
                 P([
@@ -502,8 +502,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("node-label-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("node-label-fields"),
+        get_form_help_alert(
             "node-label-fields",
             [
                 P([
@@ -550,8 +550,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("node-color-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("node-color-fields"),
+        get_form_help_alert(
             "node-color-fields",
             [
                 P([
@@ -612,8 +612,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("node-symbol-fields"),
-        get_create_config_help_alert(
+        get_form_help_btn("node-symbol-fields"),
+        get_form_help_alert(
             "node-symbol-fields",
             [
                 P([
@@ -674,8 +674,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_create_config_help_btn("link-config"),
-        get_create_config_help_alert(
+        get_form_help_btn("link-config"),
+        get_form_help_alert(
             "link-config",
             [
                 P([
@@ -784,8 +784,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("min-loops") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("min-loops") if alerts else None,
+                get_form_help_alert(
                     "min-loops",
                     [
                         P([
@@ -834,8 +834,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_create_config_help_btn("arrowheads") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("arrowheads") if alerts else None,
+                get_form_help_alert(
                     "arrowheads",
                     [P("If you check this box, the links will have "
                        "arrowheads. This is really just a stylistic choice, "
@@ -857,8 +857,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_create_config_help_btn("weight-exp") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("weight-exp") if alerts else None,
+                get_form_help_alert(
                     "weight-exp",
                     [
                         P("Enter the equation for calculating link weights. "
@@ -915,8 +915,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("weight-fltrs") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("weight-fltrs") if alerts else None,
+                get_form_help_alert(
                     "weight-fltrs",
                     [P("Filter out links with a weight less than or greater "
                        "than a certain value. You can also filter out links "
@@ -984,8 +984,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("show-weights") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("show-weights") if alerts else None,
+                get_form_help_alert(
                     "show-weights",
                     [P("If you check this box, the link weights will "
                        "be displayed.")]
@@ -1005,8 +1005,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_create_config_help_btn("attr-filters") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("attr-filters") if alerts else None,
+                get_form_help_alert(
                     "attr-filters",
                     [
                         P([
@@ -1062,8 +1062,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("all-eq") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("all-eq") if alerts else None,
+                get_form_help_alert(
                     "all-eq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have the same values for all the fields you "
@@ -1102,8 +1102,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("all-neq") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("all-neq") if alerts else None,
+                get_form_help_alert(
                     "all-neq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have different values for all the fields you "
@@ -1143,8 +1143,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_create_config_help_btn("any-eq") if alerts else None,
-                get_create_config_help_alert(
+                get_form_help_btn("any-eq") if alerts else None,
+                get_form_help_alert(
                     "any-eq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have at least one matching value across all the "
@@ -1223,8 +1223,8 @@ def get_duplicating_attr_filter_section(example_file_field_opts, index):
     return ret
 
 
-def get_create_config_help_btn(index):
-    """Get btn used to toggle alert in create config form.
+def get_form_help_btn(index):
+    """Get btn used to toggle alert in upload and create config form.
 
     :param index: Index matching alert btn toggles
     :type index: str | int
@@ -1234,7 +1234,7 @@ def get_create_config_help_btn(index):
     return dbc.Row(
         dbc.Col(
             dbc.Button("Help",
-                       id={"type": "create-config-modal-help-btn",
+                       id={"type": "form-help-btn",
                            "index": index},
                        color="info",
                        size="sm",
@@ -1245,19 +1245,20 @@ def get_create_config_help_btn(index):
     )
 
 
-def get_create_config_help_alert(index, alert_children):
-    """Get help alert in create config form.
+def get_form_help_alert(index, alert_children):
+    """Get help alert in upload and create config form.
 
     :param index: Index matching btn toggling alert
     :type index: str | int
-    :return: Help lert in create config form
+    :param alert_children: Body for alert
+    :return: Help alert in create config form
     :rtype: dbc.Row
     """
     return dbc.Row(
         dbc.Col(
             dbc.Alert(
                 alert_children,
-                id={"type": "create-config-modal-help-alert",
+                id={"type": "form-help-alert",
                     "index": index},
                 dismissable=True,
                 is_open=False,

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -121,12 +121,19 @@ def get_create_config_file_modal():
                             style={"visibility": "hidden"}
                         ),
                         dbc.Col(
-                            dbc.Button("Generate config file",
-                                       id="generate-config-file-btn"),
-                            className="text-right my-auto",
-                            width=6
+                            dbc.Button(I(className="bi-download",
+                                         style={"font-size": 16}),
+                                       id="download-config-file-btn"),
+                            width="auto"
+                        ),
+                        dbc.Col(
+                            dbc.Button(I(className="bi-arrow-return-right",
+                                         style={"font-size": 16}),
+                                       id="return-config-file-btn"),
+                            width="auto"
                         )
                     ],
+                    justify="end",
                     style={"width": "100%"}
                 )
             )

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -17,18 +17,70 @@ def get_upload_data_modal():
         [
             dbc.ModalHeader("Upload tabular data"),
             dbc.ModalBody([
-                dcc.Upload(
-                    dbc.Button("Select tabular data file",
-                               id="select-sample-file-btn"),
-                    id="upload-sample-file"
-                ),
-                dcc.Upload(
-                    dbc.Button("Optional matrix file",
-                               id="select-matrix-file-btn",
-                               color="light",
-                               style={"display": "none"}),
-                    id="upload-matrix-file",
-                    className="mt-2"
+                dbc.Row([
+                    dbc.Col(
+                        dcc.Upload(
+                            dbc.Button("Select tabular data file",
+                                       id="select-sample-file-btn"),
+                            id="upload-sample-file"
+                        ),
+                        width="auto"
+                    ),
+                    dbc.Col(
+                        dbc.Row([
+                            dbc.Col(
+                                dbc.Button("Help",
+                                           id="select-sample-file-btn-help",
+                                           color="info",
+                                           size="sm",
+                                           className="p-0")
+                            ),
+                            dbc.Col(
+                                dbc.Button("Delete",
+                                           id="select-sample-file-btn-del",
+                                           color="danger",
+                                           size="sm",
+                                           className="p-0")
+                            )
+                        ]),
+                        width="auto"
+                    )
+                ], justify="between"),
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            dcc.Upload(
+                                dbc.Button("Optional matrix file",
+                                           id="select-matrix-file-btn",
+                                           color="light"),
+                                id="upload-matrix-file",
+                            ),
+                            width="auto"
+                        ),
+                        dbc.Col(
+                            dbc.Row([
+                                dbc.Col(
+                                    dbc.Button("Help",
+                                               id="select-matrix-file-btn-help",
+                                               color="info",
+                                               size="sm",
+                                               className="p-0")
+                                ),
+                                dbc.Col(
+                                    dbc.Button("Delete",
+                                               id="select-matrix-file-btn-del",
+                                               color="danger",
+                                               size="sm",
+                                               className="p-0")
+                                )
+                            ]),
+                            width="auto"
+                        )
+                    ],
+                    className="mt-2",
+                    id="select-matrix-file-row",
+                    justify="between",
+                    style={"display": "none"}
                 )
             ]),
             dbc.ModalHeader("Upload config file",
@@ -36,15 +88,42 @@ def get_upload_data_modal():
                             style={"display": "none"}),
             dbc.ModalBody(
                 [
-                    dcc.Upload(
-                        dbc.Button("Select config file",
-                                   id="select-config-file-btn"),
-                        id="upload-config-file"
-                    ),
-                    dbc.Button(
-                        "...or click here to create one from scratch",
-                        id="create-config-file-btn",
-                        color="link"
+                    dbc.Row([
+                        dbc.Col(
+                            dcc.Upload(
+                                dbc.Button("Select config file",
+                                           id="select-config-file-btn"),
+                                id="upload-config-file"
+                            ),
+                        ),
+                        dbc.Col(
+                            dbc.Row([
+                                dbc.Col(
+                                    dbc.Button("Help",
+                                               id="select-config-file-btn-help",
+                                               color="info",
+                                               size="sm",
+                                               className="p-0")
+                                ),
+                                dbc.Col(
+                                    dbc.Button("Delete",
+                                               id="select-config-file-btn-del",
+                                               color="danger",
+                                               size="sm",
+                                               className="p-0")
+                                )
+                            ]),
+                            width="auto"
+                        )
+                    ], justify="between"),
+                    dbc.Row(
+                        dbc.Col(
+                            dbc.Button(
+                                "...or click here to create one from scratch",
+                                id="create-config-file-btn",
+                                color="link"
+                            )
+                        )
                     )
                 ],
                 id="select-config-file-modal-body",

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -126,11 +126,19 @@ def get_create_config_file_modal():
                                        id="download-config-file-btn"),
                             width="auto"
                         ),
+                        dbc.Tooltip(
+                            "Download config file",
+                            target="download-config-file-btn"
+                        ),
                         dbc.Col(
                             dbc.Button(I(className="bi-arrow-return-right",
                                          style={"font-size": 16}),
                                        id="return-config-file-btn"),
                             width="auto"
+                        ),
+                        dbc.Tooltip(
+                            "Return to previous window with this config file",
+                            target="return-config-file-btn"
                         )
                     ],
                     justify="end",

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -52,6 +52,11 @@ def get_upload_data_modal():
             ),
             dbc.ModalFooter(
                 dbc.Button("Visualize", id="viz-btn")
+            ),
+            dbc.ModalBody(
+                "",
+                className="d-none pt-0 text-danger",
+                id="upload-error-msg"
             )
         ],
         id="upload-data-modal"

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -27,16 +27,9 @@ def get_upload_data_modal():
                         width="auto"
                     ),
                     dbc.Col(
-                        dbc.Row([
-                            get_upload_help_btn("select-sample-file"),
-                            dbc.Col(
-                                dbc.Button("Delete",
-                                           id="select-sample-file-btn-del",
-                                           color="danger",
-                                           size="sm",
-                                           className="p-0")
-                            )
-                        ]),
+                        dbc.Row(
+                            get_upload_help_btn("select-sample-file")
+                        ),
                         width="auto"
                     )
                 ], justify="between"),
@@ -121,16 +114,9 @@ def get_upload_data_modal():
                             ),
                         ),
                         dbc.Col(
-                            dbc.Row([
-                                get_upload_help_btn("select-config-file"),
-                                dbc.Col(
-                                    dbc.Button("Delete",
-                                               id="select-config-file-btn-del",
-                                               color="danger",
-                                               size="sm",
-                                               className="p-0")
-                                )
-                            ]),
+                            dbc.Row(
+                                get_upload_help_btn("select-config-file")
+                            ),
                             width="auto"
                         )
                     ], justify="between"),

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -42,7 +42,26 @@ def get_upload_data_modal():
                 ], justify="between"),
                 dbc.Row(
                     dbc.Col(
-                        get_upload_help_alert("select-sample-file", "foo")
+                        get_upload_help_alert("select-sample-file",[
+                            P("The rows of your tabular dataset should "
+                              "describe individual AMR bacteria samples. You "
+                              "must have some sort of a sample ID column, and "
+                              "some sort of sampling date column."),
+                            P("There are no other rigid or standardized "
+                              "requirements expected for tabular datasets, but"
+                              "you should ideally have multiple other columns "
+                              "relevant to analyzing the AMR transmission "
+                              "dynamics of bacteria (e.g., plasmid "
+                              "classifications and sampling locations)."),
+                            P([
+                                "You can find example tabular dataset files ",
+                                A("here.",
+                                  href="https://github.com/ivansg44/AMR-TV/"
+                                       "tree/development/sample_files",
+                                  target="_blank",
+                                  rel="noopener noreferrer")
+                            ]),
+                        ])
                     )
                 ),
                 dbc.Row(
@@ -77,7 +96,14 @@ def get_upload_data_modal():
                 ),
                 dbc.Row(
                     dbc.Col(
-                        get_upload_help_alert("select-matrix-file", "foo")
+                        get_upload_help_alert("select-matrix-file", [
+                            P("The optional matrix file allows you to input "
+                              "pairwise data values between the samples in "
+                              "your tabular dataset (e.g., pairwise genetic "
+                              "similarity or distance measurements). These "
+                              "can be later referenced in the config file "
+                              "when setting criteria for links between nodes.")
+                        ])
                     )
                 ),
             ]),
@@ -111,7 +137,7 @@ def get_upload_data_modal():
                     dbc.Row(
                         dbc.Col(
                             dbc.Button(
-                                "...or click here to create one from scratch",
+                                "...or click here to create one through a detailed web form",
                                 id="create-config-file-btn",
                                 color="link"
                             )
@@ -119,7 +145,41 @@ def get_upload_data_modal():
                     ),
                     dbc.Row(
                         dbc.Col(
-                            get_upload_help_alert("select-config-file", "foo")
+                            get_upload_help_alert("select-config-file", [
+                                P(B("The configuration file is a JSON file "
+                                    "that instructs AMR-TV on how to parse and "
+                                    "visualize the tabular dataset.")),
+                                P([
+                                    "The expected format of this file is "
+                                    "heavily standardized, and not easy to "
+                                    "write from scratch. We recommend creating "
+                                    "new config files using ",
+                                    A("the more intuitive web form available "
+                                      "directly inside the AMR-TV interface.",
+                                      href="#",
+                                      id="create-config-file-link")
+                                ]),
+                                P([
+                                    "If you must create one without using the "
+                                    "built-in web form, you can read a "
+                                    "detailed description on the config file "
+                                    "format in Tables C.1 and C.2 of ",
+                                    A(I("Interactive visualizations for two "
+                                        "large public health datasets."),
+                                      href="https://dx.doi.org/10.14288/"
+                                           "1.0431521",
+                                      target="_blank",
+                                      rel="noopener noreferrer")
+                                ]),
+                                P([
+                                    "You can find example config files ",
+                                    A("here.",
+                                      href="https://github.com/ivansg44/AMR-TV/"
+                                           "tree/development/config_files",
+                                      target="_blank",
+                                      rel="noopener noreferrer")
+                                ]),
+                            ])
                         )
                     ),
                 ],

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -244,8 +244,8 @@ def get_create_config_modal_form(example_file_field_opts):
     :rtype: list
     """
     ret = [
-        get_form_help_btn("sample-id-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("sample-id-fields"),
+        get_create_config_help_alert(
             "sample-id-fields",
             [
                 P([
@@ -271,8 +271,8 @@ def get_create_config_modal_form(example_file_field_opts):
             ),
             className="mb-3"
         ),
-        get_form_help_btn("date-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("date-fields"),
+        get_create_config_help_alert(
             "date-fields",
             [
                 P([
@@ -332,8 +332,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("link-across-primary-y-field"),
-        get_form_help_alert(
+        get_create_config_help_btn("link-across-primary-y-field"),
+        get_create_config_help_alert(
             "link-across-primary-y-field",
             [
                 P([
@@ -365,8 +365,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("max-day-range-field"),
-        get_form_help_alert(
+        get_create_config_help_btn("max-day-range-field"),
+        get_create_config_help_alert(
             "max-day-range-field",
             [P("Links will not be drawn between nodes that were sampled more "
                "than this many days apart.")]
@@ -388,8 +388,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("null-val-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("null-val-fields"),
+        get_create_config_help_alert(
             "null-val-fields",
             [
                 P([
@@ -448,8 +448,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("y-axis-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("y-axis-fields"),
+        get_create_config_help_alert(
             "y-axis-fields",
             [
                 P([
@@ -502,8 +502,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("node-label-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("node-label-fields"),
+        get_create_config_help_alert(
             "node-label-fields",
             [
                 P([
@@ -550,8 +550,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("node-color-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("node-color-fields"),
+        get_create_config_help_alert(
             "node-color-fields",
             [
                 P([
@@ -612,8 +612,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("node-symbol-fields"),
-        get_form_help_alert(
+        get_create_config_help_btn("node-symbol-fields"),
+        get_create_config_help_alert(
             "node-symbol-fields",
             [
                 P([
@@ -674,8 +674,8 @@ def get_create_config_modal_form(example_file_field_opts):
             className="mb-3"
         ),
         Hr(),
-        get_form_help_btn("link-config"),
-        get_form_help_alert(
+        get_create_config_help_btn("link-config"),
+        get_create_config_help_alert(
             "link-config",
             [
                 P([
@@ -784,8 +784,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("min-loops") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("min-loops") if alerts else None,
+                get_create_config_help_alert(
                     "min-loops",
                     [
                         P([
@@ -834,8 +834,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_form_help_btn("arrowheads") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("arrowheads") if alerts else None,
+                get_create_config_help_alert(
                     "arrowheads",
                     [P("If you check this box, the links will have "
                        "arrowheads. This is really just a stylistic choice, "
@@ -857,8 +857,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_form_help_btn("weight-exp") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("weight-exp") if alerts else None,
+                get_create_config_help_alert(
                     "weight-exp",
                     [
                         P("Enter the equation for calculating link weights. "
@@ -915,8 +915,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("weight-fltrs") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("weight-fltrs") if alerts else None,
+                get_create_config_help_alert(
                     "weight-fltrs",
                     [P("Filter out links with a weight less than or greater "
                        "than a certain value. You can also filter out links "
@@ -984,8 +984,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("show-weights") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("show-weights") if alerts else None,
+                get_create_config_help_alert(
                     "show-weights",
                     [P("If you check this box, the link weights will "
                        "be displayed.")]
@@ -1005,8 +1005,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ],
                     className="mb-3"
                 ),
-                get_form_help_btn("attr-filters") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("attr-filters") if alerts else None,
+                get_create_config_help_alert(
                     "attr-filters",
                     [
                         P([
@@ -1062,8 +1062,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("all-eq") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("all-eq") if alerts else None,
+                get_create_config_help_alert(
                     "all-eq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have the same values for all the fields you "
@@ -1102,8 +1102,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("all-neq") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("all-neq") if alerts else None,
+                get_create_config_help_alert(
                     "all-neq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have different values for all the fields you "
@@ -1143,8 +1143,8 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                     ),
                     className="mb-3"
                 ),
-                get_form_help_btn("any-eq") if alerts else None,
-                get_form_help_alert(
+                get_create_config_help_btn("any-eq") if alerts else None,
+                get_create_config_help_alert(
                     "any-eq",
                     [P("In order to draw a link between any two nodes, they "
                        "must have at least one matching value across all the "
@@ -1223,8 +1223,8 @@ def get_duplicating_attr_filter_section(example_file_field_opts, index):
     return ret
 
 
-def get_form_help_btn(index):
-    """Get btn used to toggle alert in upload and create config form.
+def get_create_config_help_btn(index):
+    """Get btn used to toggle alert in create config form.
 
     :param index: Index matching alert btn toggles
     :type index: str | int
@@ -1234,7 +1234,7 @@ def get_form_help_btn(index):
     return dbc.Row(
         dbc.Col(
             dbc.Button("Help",
-                       id={"type": "form-help-btn",
+                       id={"type": "create-config-modal-help-btn",
                            "index": index},
                        color="info",
                        size="sm",
@@ -1245,20 +1245,19 @@ def get_form_help_btn(index):
     )
 
 
-def get_form_help_alert(index, alert_children):
-    """Get help alert in upload and create config form.
+def get_create_config_help_alert(index, alert_children):
+    """Get help alert in create config form.
 
     :param index: Index matching btn toggling alert
     :type index: str | int
-    :param alert_children: Body for alert
-    :return: Help alert in create config form
+    :return: Help lert in create config form
     :rtype: dbc.Row
     """
     return dbc.Row(
         dbc.Col(
             dbc.Alert(
                 alert_children,
-                id={"type": "form-help-alert",
+                id={"type": "create-config-modal-help-alert",
                     "index": index},
                 dismissable=True,
                 is_open=False,

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -28,13 +28,7 @@ def get_upload_data_modal():
                     ),
                     dbc.Col(
                         dbc.Row([
-                            dbc.Col(
-                                dbc.Button("Help",
-                                           id="select-sample-file-btn-help",
-                                           color="info",
-                                           size="sm",
-                                           className="p-0")
-                            ),
+                            get_upload_help_btn("select-sample-file"),
                             dbc.Col(
                                 dbc.Button("Delete",
                                            id="select-sample-file-btn-del",
@@ -46,6 +40,11 @@ def get_upload_data_modal():
                         width="auto"
                     )
                 ], justify="between"),
+                dbc.Row(
+                    dbc.Col(
+                        get_upload_help_alert("select-sample-file", "foo")
+                    )
+                ),
                 dbc.Row(
                     [
                         dbc.Col(
@@ -59,13 +58,7 @@ def get_upload_data_modal():
                         ),
                         dbc.Col(
                             dbc.Row([
-                                dbc.Col(
-                                    dbc.Button("Help",
-                                               id="select-matrix-file-btn-help",
-                                               color="info",
-                                               size="sm",
-                                               className="p-0")
-                                ),
+                                get_upload_help_btn("select-matrix-file"),
                                 dbc.Col(
                                     dbc.Button("Delete",
                                                id="select-matrix-file-btn-del",
@@ -81,7 +74,12 @@ def get_upload_data_modal():
                     id="select-matrix-file-row",
                     justify="between",
                     style={"display": "none"}
-                )
+                ),
+                dbc.Row(
+                    dbc.Col(
+                        get_upload_help_alert("select-matrix-file", "foo")
+                    )
+                ),
             ]),
             dbc.ModalHeader("Upload config file",
                             id="select-config-file-modal-header",
@@ -98,13 +96,7 @@ def get_upload_data_modal():
                         ),
                         dbc.Col(
                             dbc.Row([
-                                dbc.Col(
-                                    dbc.Button("Help",
-                                               id="select-config-file-btn-help",
-                                               color="info",
-                                               size="sm",
-                                               className="p-0")
-                                ),
+                                get_upload_help_btn("select-config-file"),
                                 dbc.Col(
                                     dbc.Button("Delete",
                                                id="select-config-file-btn-del",
@@ -124,7 +116,12 @@ def get_upload_data_modal():
                                 color="link"
                             )
                         )
-                    )
+                    ),
+                    dbc.Row(
+                        dbc.Col(
+                            get_upload_help_alert("select-config-file", "foo")
+                        )
+                    ),
                 ],
                 id="select-config-file-modal-body",
                 style={"display": "none"}
@@ -1250,7 +1247,8 @@ def get_create_config_help_alert(index, alert_children):
 
     :param index: Index matching btn toggling alert
     :type index: str | int
-    :return: Help lert in create config form
+    :param alert_children: Body of alert
+    :return: Help alert in create config form
     :rtype: dbc.Row
     """
     return dbc.Row(
@@ -1258,6 +1256,48 @@ def get_create_config_help_alert(index, alert_children):
             dbc.Alert(
                 alert_children,
                 id={"type": "create-config-modal-help-alert",
+                    "index": index},
+                dismissable=True,
+                is_open=False,
+                color="info"
+            )
+        ),
+        className="mt-1"
+    )
+
+
+def get_upload_help_btn(index):
+    """Get btn used to toggle alert in upload form.
+
+    :param index: Index matching alert btn toggles
+    :type index: str | int
+    :return: Btn used to toggle alert in upload form
+    :rtype: dbc.Row
+    """
+    return dbc.Col(
+        dbc.Button("Help",
+                   id={"type": "upload-modal-help-btn",
+                       "index": index},
+                   color="info",
+                   size="sm",
+                   className="p-0")
+    )
+
+
+def get_upload_help_alert(index, alert_children):
+    """Get help alert in upload form.
+
+    :param index: Index matching btn toggling alert
+    :type index: str | int
+    :param alert_children: Body of alert
+    :return: Help alert in upload form
+    :rtype: dbc.Row
+    """
+    return dbc.Row(
+        dbc.Col(
+            dbc.Alert(
+                alert_children,
+                id={"type": "upload-modal-help-alert",
                     "index": index},
                 dismissable=True,
                 is_open=False,

--- a/modal_generator.py
+++ b/modal_generator.py
@@ -898,7 +898,28 @@ def get_duplicating_link_section(example_file_field_opts, index, alerts=False):
                         ],
                         width={"offset": 1, "size": 8}
                     ),
-                    className="mb-1"
+                    className="mb-3"
+                ),
+                get_create_config_help_btn("show-weights") if alerts else None,
+                get_create_config_help_alert(
+                    "show-weights",
+                    [P("If you check this box, the link weights will "
+                       "be displayed.")]
+                ) if alerts else None,
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            dbc.Checkbox(
+                                id={"type": "show-link-weights", "index": index},
+                                checked=False
+                            ),
+                            width=1
+                        ),
+                        dbc.Col(
+                            dbc.Label("Show weights?")
+                        )
+                    ],
+                    className="mb-3"
                 ),
                 get_create_config_help_btn("attr-filters") if alerts else None,
                 get_create_config_help_alert(


### PR DESCRIPTION
Resolves #69 

Steps:
* ~~Re-arrange order of btns in modal~~
* ~~Make btns appear at proper order in workflow~~
  * ~~Tabular dataset -> optional matrix and config file at same time~~
* Allow user to upload config file or create one
  * ~~Btn inside upload modal opens create config modal~~
  * ~~We can remove create config btn from main page~~
  * ~~Carry uploaded tabular file inside create config modal~~
  * ~~Carry generated config file inside upload modal~~
    * ~~Button for downloading file~~
    * ~~Button for returning to upload modal with file~~
    * Button for returning to upload modal without file
  * If user uploads config file, populate create config modal with uploaded file
* ~~Small "clear data" btn beside upload matrix btn (rest do not need; cuz they are mandatory)~~
* ~~Small "hint" btns beside each btn, which explain expected formats~~
* Validation logic
  * Green btn -> ok
  * Red btn + error message
* Disable viz btn if data is invalid
* ~~Fallback: unforseen errors should be caught and displayed in writing on upload modal~~